### PR TITLE
Android: Fix crashes caused by tracy updates

### DIFF
--- a/externals/tracy/public/client/TracyProfiler.cpp
+++ b/externals/tracy/public/client/TracyProfiler.cpp
@@ -3474,22 +3474,7 @@ bool Profiler::HandleServerQuery()
         }
         else
         {
-            auto t = GetThreadNameData( (uint32_t)ptr );
-            if( t )
-            {
-                SendString( ptr, t->name, QueueType::ThreadName );
-                if( t->groupHint != 0 )
-                {
-                    TracyLfqPrepare( QueueType::ThreadGroupHint );
-                    MemWrite( &item->threadGroupHint.thread, (uint32_t)ptr );
-                    MemWrite( &item->threadGroupHint.groupHint, t->groupHint );
-                    TracyLfqCommit;
-                }
-            }
-            else
-            {
-                SendString( ptr, GetThreadName( (uint32_t)ptr ), QueueType::ThreadName );
-            }
+            SendString( ptr, GetThreadName( (uint32_t)ptr ), QueueType::ThreadName );
         }
         break;
     case ServerQuerySourceLocation:
@@ -3727,7 +3712,6 @@ void Profiler::ReportTopology()
     struct CpuData
     {
         uint32_t package;
-        uint32_t die;
         uint32_t core;
         uint32_t thread;
     };
@@ -3746,12 +3730,6 @@ void Profiler::ReportTopology()
     auto res = _GetLogicalProcessorInformationEx( RelationProcessorPackage, packageInfo, &psz );
     assert( res );
 
-    DWORD dsz = 0;
-    _GetLogicalProcessorInformationEx( RelationProcessorDie, nullptr, &dsz );
-    auto dieInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( dsz );
-    res = _GetLogicalProcessorInformationEx( RelationProcessorDie, dieInfo, &dsz );
-    assert( res );
-
     DWORD csz = 0;
     _GetLogicalProcessorInformationEx( RelationProcessorCore, nullptr, &csz );
     auto coreInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( csz );
@@ -3763,7 +3741,6 @@ void Profiler::ReportTopology()
     const uint32_t numcpus = sysinfo.dwNumberOfProcessors;
 
     auto cpuData = (CpuData*)tracy_malloc( sizeof( CpuData ) * numcpus );
-    memset( cpuData, 0, sizeof( CpuData ) * numcpus );
     for( uint32_t i=0; i<numcpus; i++ ) cpuData[i].thread = i;
 
     int idx = 0;
@@ -3777,24 +3754,6 @@ void Profiler::ReportTopology()
         while( mask != 0 )
         {
             if( mask & 1 ) cpuData[core].package = idx;
-            core++;
-            mask >>= 1;
-        }
-        ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)(((char*)ptr) + ptr->Size);
-        idx++;
-    }
-
-    idx = 0;
-    ptr = dieInfo;
-    while( (char*)ptr < ((char*)dieInfo) + dsz )
-    {
-        assert( ptr->Relationship == RelationProcessorDie );
-        // FIXME account for GroupCount
-        auto mask = ptr->Processor.GroupMask[0].Mask;
-        int core = 0;
-        while( mask != 0 )
-        {
-            if( mask & 1 ) cpuData[core].die = idx;
             core++;
             mask >>= 1;
         }
@@ -3826,7 +3785,6 @@ void Profiler::ReportTopology()
 
         TracyLfqPrepare( QueueType::CpuTopology );
         MemWrite( &item->cpuTopology.package, data.package );
-        MemWrite( &item->cpuTopology.die, data.die );
         MemWrite( &item->cpuTopology.core, data.core );
         MemWrite( &item->cpuTopology.thread, data.thread );
 
@@ -3862,20 +3820,12 @@ void Profiler::ReportTopology()
         fclose( f );
         cpuData[i].package = uint32_t( atoi( buf ) );
         cpuData[i].thread = i;
-
         sprintf( path, "%s%i/topology/core_id", basePath, i );
         f = fopen( path, "rb" );
         read = fread( buf, 1, 1024, f );
         buf[read] = '\0';
         fclose( f );
         cpuData[i].core = uint32_t( atoi( buf ) );
-
-        sprintf( path, "%s%i/topology/die_id", basePath, i );
-        f = fopen( path, "rb" );
-        read = fread( buf, 1, 1024, f );
-        buf[read] = '\0';
-        fclose( f );
-        cpuData[i].die = uint32_t( atoi( buf ) );
     }
 
     for( int i=0; i<numcpus; i++ )
@@ -3884,7 +3834,6 @@ void Profiler::ReportTopology()
 
         TracyLfqPrepare( QueueType::CpuTopology );
         MemWrite( &item->cpuTopology.package, data.package );
-        MemWrite( &item->cpuTopology.die, data.die );
         MemWrite( &item->cpuTopology.core, data.core );
         MemWrite( &item->cpuTopology.thread, data.thread );
 
@@ -4760,7 +4709,7 @@ TRACY_API int ___tracy_connected( void )
 }
 
 #ifdef TRACY_FIBERS
-TRACY_API void ___tracy_fiber_enter( const char* fiber ){ tracy::Profiler::EnterFiber( fiber, 0 ); }
+TRACY_API void ___tracy_fiber_enter( const char* fiber ){ tracy::Profiler::EnterFiber( fiber ); }
 TRACY_API void ___tracy_fiber_leave( void ){ tracy::Profiler::LeaveFiber(); }
 #endif
 

--- a/externals/tracy/public/client/TracyProfiler.hpp
+++ b/externals/tracy/public/client/TracyProfiler.hpp
@@ -675,12 +675,11 @@ public:
     }
 
 #ifdef TRACY_FIBERS
-    static tracy_force_inline void EnterFiber( const char* fiber, int32_t groupHint )
+    static tracy_force_inline void EnterFiber( const char* fiber )
     {
         TracyQueuePrepare( QueueType::FiberEnter );
         MemWrite( &item->fiberEnter.time, GetTime() );
         MemWrite( &item->fiberEnter.fiber, (uint64_t)fiber );
-        MemWrite( &item->fiberEnter.groupHint, groupHint );
         TracyQueueCommit( fiberEnter );
     }
 

--- a/externals/tracy/public/client/TracyScoped.hpp
+++ b/externals/tracy/public/client/TracyScoped.hpp
@@ -126,7 +126,7 @@ public:
         TracyQueueCommit( zoneTextFatThread );
     }
 
-    void TextFmt( const char* fmt, ... )
+    tracy_force_inline void TextFmt( const char* fmt, ... )
     {
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND
@@ -165,7 +165,7 @@ public:
         TracyQueueCommit( zoneTextFatThread );
     }
 
-    void NameFmt( const char* fmt, ... )
+    tracy_force_inline void NameFmt( const char* fmt, ... )
     {
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND

--- a/externals/tracy/public/client/TracySysTrace.cpp
+++ b/externals/tracy/public/client/TracySysTrace.cpp
@@ -16,25 +16,16 @@
 namespace tracy
 {
 
-static int GetSamplingFrequency()
+static constexpr int GetSamplingFrequency()
 {
-    int samplingHz = TRACY_SAMPLING_HZ;
-
-    auto env = GetEnvVar( "TRACY_SAMPLING_HZ" );
-    if( env )
-    {
-        int val = atoi( env );
-        if( val > 0 ) samplingHz = val;
-    }
-
 #if defined _WIN32
-    return samplingHz > 8000 ? 8000 : ( samplingHz < 1 ? 1 : samplingHz );
+    return TRACY_SAMPLING_HZ > 8000 ? 8000 : ( TRACY_SAMPLING_HZ < 1 ? 1 : TRACY_SAMPLING_HZ );
 #else
-    return samplingHz > 1000000 ? 1000000 : ( samplingHz < 1 ? 1 : samplingHz );
+    return TRACY_SAMPLING_HZ > 1000000 ? 1000000 : ( TRACY_SAMPLING_HZ < 1 ? 1 : TRACY_SAMPLING_HZ );
 #endif
 }
 
-static int GetSamplingPeriod()
+static constexpr int GetSamplingPeriod()
 {
     return 1000000000 / GetSamplingFrequency();
 }
@@ -330,7 +321,7 @@ static void SetupVsync()
 #endif
 }
 
-static int GetSamplingInterval()
+static constexpr int GetSamplingInterval()
 {
     return GetSamplingPeriod() / 100;
 }

--- a/externals/tracy/public/common/TracyProtocol.hpp
+++ b/externals/tracy/public/common/TracyProtocol.hpp
@@ -9,7 +9,7 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 69 };
+enum : uint32_t { ProtocolVersion = 66 };
 enum : uint16_t { BroadcastVersion = 3 };
 
 using lz4sz_t = uint32_t;

--- a/externals/tracy/public/common/TracyQueue.hpp
+++ b/externals/tracy/public/common/TracyQueue.hpp
@@ -108,7 +108,6 @@ enum class QueueType : uint8_t
     SingleStringData,
     SecondStringData,
     MemNamePayload,
-    ThreadGroupHint,
     StringData,
     ThreadName,
     PlotName,
@@ -260,7 +259,6 @@ struct QueueFiberEnter
     int64_t time;
     uint64_t fiber;     // ptr
     uint32_t thread;
-    int32_t groupHint;
 };
 
 struct QueueFiberLeave
@@ -479,12 +477,6 @@ struct QueueMemNamePayload
     uint64_t name;
 };
 
-struct QueueThreadGroupHint
-{
-    uint32_t thread;
-    int32_t groupHint;
-};
-
 struct QueueMemAlloc
 {
     int64_t time;
@@ -647,7 +639,6 @@ struct QueueSourceCodeNotAvailable
 struct QueueCpuTopology
 {
     uint32_t package;
-    uint32_t die;
     uint32_t core;
     uint32_t thread;
 };
@@ -741,7 +732,6 @@ struct QueueItem
         QueueMemAlloc memAlloc;
         QueueMemFree memFree;
         QueueMemNamePayload memName;
-        QueueThreadGroupHint threadGroupHint;
         QueueCallstackFat callstackFat;
         QueueCallstackFatThread callstackFatThread;
         QueueCallstackAllocFat callstackAllocFat;
@@ -878,7 +868,6 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ),                                  // single string data
     sizeof( QueueHeader ),                                  // second string data
     sizeof( QueueHeader ) + sizeof( QueueMemNamePayload ),
-    sizeof( QueueHeader ) + sizeof( QueueThreadGroupHint ),
     // keep all QueueStringTransfer below
     sizeof( QueueHeader ) + sizeof( QueueStringTransfer ),  // string data
     sizeof( QueueHeader ) + sizeof( QueueStringTransfer ),  // thread name

--- a/externals/tracy/public/common/TracySystem.cpp
+++ b/externals/tracy/public/common/TracySystem.cpp
@@ -101,6 +101,12 @@ TRACY_API uint32_t GetThreadHandleImpl()
 }
 
 #ifdef TRACY_ENABLE
+struct ThreadNameData
+{
+    uint32_t id;
+    const char* name;
+    ThreadNameData* next;
+};
 std::atomic<ThreadNameData*>& GetThreadNameData();
 #endif
 
@@ -128,11 +134,6 @@ void ThreadNameMsvcMagic( const THREADNAME_INFO& info )
 #endif
 
 TRACY_API void SetThreadName( const char* name )
-{
-    SetThreadNameWithHint( name, 0 );
-}
-
-TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint )
 {
 #if defined _WIN32
 #  ifdef TRACY_UWP
@@ -204,29 +205,12 @@ TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint )
         buf[sz] = '\0';
         auto data = (ThreadNameData*)tracy_malloc_fast( sizeof( ThreadNameData ) );
         data->id = detail::GetThreadHandleImpl();
-        data->groupHint = groupHint;
         data->name = buf;
         data->next = GetThreadNameData().load( std::memory_order_relaxed );
         while( !GetThreadNameData().compare_exchange_weak( data->next, data, std::memory_order_release, std::memory_order_relaxed ) ) {}
     }
 #endif
 }
-
-#ifdef TRACY_ENABLE
-ThreadNameData* GetThreadNameData( uint32_t id )
-{
-    auto ptr = GetThreadNameData().load( std::memory_order_relaxed );
-    while( ptr )
-    {
-        if( ptr->id == id )
-        {
-            return ptr;
-        }
-        ptr = ptr->next;
-    }
-    return nullptr;
-}
-#endif
 
 TRACY_API const char* GetThreadName( uint32_t id )
 {

--- a/externals/tracy/public/common/TracySystem.hpp
+++ b/externals/tracy/public/common/TracySystem.hpp
@@ -14,16 +14,6 @@ TRACY_API uint32_t GetThreadHandleImpl();
 }
 
 #ifdef TRACY_ENABLE
-struct ThreadNameData
-{
-    uint32_t id;
-    int32_t groupHint;
-    const char* name;
-    ThreadNameData* next;
-};
-
-ThreadNameData* GetThreadNameData( uint32_t id );
-
 TRACY_API uint32_t GetThreadHandle();
 #else
 static inline uint32_t GetThreadHandle()
@@ -33,7 +23,6 @@ static inline uint32_t GetThreadHandle()
 #endif
 
 TRACY_API void SetThreadName( const char* name );
-TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint );
 TRACY_API const char* GetThreadName( uint32_t id );
 
 TRACY_API const char* GetEnvVar( const char* name );

--- a/externals/tracy/public/common/TracyVersion.hpp
+++ b/externals/tracy/public/common/TracyVersion.hpp
@@ -7,7 +7,7 @@ namespace Version
 {
 enum { Major = 0 };
 enum { Minor = 11 };
-enum { Patch = 2 };
+enum { Patch = 0 };
 }
 }
 

--- a/externals/tracy/public/libbacktrace/dwarf.cpp
+++ b/externals/tracy/public/libbacktrace/dwarf.cpp
@@ -725,8 +725,8 @@ struct dwarf_data
   struct dwarf_data *next;
   /* The data for .gnu_debugaltlink.  */
   struct dwarf_data *altlink;
-/* The base address mapping for this file.  */
-  struct libbacktrace_base_address base_address;
+  /* The base address for this file.  */
+  uintptr_t base_address;
   /* A sorted list of address ranges.  */
   struct unit_addrs *addrs;
   /* Number of address ranges in list.  */
@@ -1947,9 +1947,8 @@ update_pcrange (const struct attr* attr, const struct attr_val* val,
 static int
 add_low_high_range (struct backtrace_state *state,
 		    const struct dwarf_sections *dwarf_sections,
-		    struct libbacktrace_base_address base_address,
-		    int is_bigendian, struct unit *u,
-		    const struct pcrange *pcrange,
+		    uintptr_t base_address, int is_bigendian,
+		    struct unit *u, const struct pcrange *pcrange,
 		    int (*add_range) (struct backtrace_state *state,
 				      void *rdata, uintptr_t lowpc,
 				      uintptr_t highpc,
@@ -1984,8 +1983,8 @@ add_low_high_range (struct backtrace_state *state,
 
   /* Add in the base address of the module when recording PC values,
      so that we can look up the PC directly.  */
-  lowpc = libbacktrace_add_base (lowpc, base_address);
-  highpc = libbacktrace_add_base (highpc, base_address);
+  lowpc += base_address;
+  highpc += base_address;
 
   return add_range (state, rdata, lowpc, highpc, error_callback, data, vec);
 }
@@ -1997,7 +1996,7 @@ static int
 add_ranges_from_ranges (
     struct backtrace_state *state,
     const struct dwarf_sections *dwarf_sections,
-    struct libbacktrace_base_address base_address, int is_bigendian,
+    uintptr_t base_address, int is_bigendian,
     struct unit *u, uintptr_t base,
     const struct pcrange *pcrange,
     int (*add_range) (struct backtrace_state *state, void *rdata,
@@ -2043,11 +2042,10 @@ add_ranges_from_ranges (
 	base = (uintptr_t) high;
       else
 	{
-	  uintptr_t rl, rh;
-
-	  rl = libbacktrace_add_base ((uintptr_t) low + base, base_address);
-	  rh = libbacktrace_add_base ((uintptr_t) high + base, base_address);
-	  if (!add_range (state, rdata, rl, rh, error_callback, data, vec))
+	  if (!add_range (state, rdata, 
+			  (uintptr_t) low + base + base_address,
+			  (uintptr_t) high + base + base_address,
+			  error_callback, data, vec))
 	    return 0;
 	}
     }
@@ -2065,7 +2063,7 @@ static int
 add_ranges_from_rnglists (
     struct backtrace_state *state,
     const struct dwarf_sections *dwarf_sections,
-    struct libbacktrace_base_address base_address, int is_bigendian,
+    uintptr_t base_address, int is_bigendian,
     struct unit *u, uintptr_t base,
     const struct pcrange *pcrange,
     int (*add_range) (struct backtrace_state *state, void *rdata,
@@ -2148,10 +2146,9 @@ add_ranges_from_rnglists (
 				     u->addrsize, is_bigendian, index,
 				     error_callback, data, &high))
 	      return 0;
-	    if (!add_range (state, rdata,
-			    libbacktrace_add_base (low, base_address),
-			    libbacktrace_add_base (high, base_address),
-			    error_callback, data, vec))
+	    if (!add_range (state, rdata, low + base_address,
+			    high + base_address, error_callback, data,
+			    vec))
 	      return 0;
 	  }
 	  break;
@@ -2168,7 +2165,7 @@ add_ranges_from_rnglists (
 				     error_callback, data, &low))
 	      return 0;
 	    length = read_uleb128 (&rnglists_buf);
-	    low = libbacktrace_add_base (low, base_address);
+	    low += base_address;
 	    if (!add_range (state, rdata, low, low + length,
 			    error_callback, data, vec))
 	      return 0;
@@ -2182,9 +2179,8 @@ add_ranges_from_rnglists (
 
 	    low = read_uleb128 (&rnglists_buf);
 	    high = read_uleb128 (&rnglists_buf);
-	    if (!add_range (state, rdata,
-			    libbacktrace_add_base (low + base, base_address),
-			    libbacktrace_add_base (high + base, base_address),
+	    if (!add_range (state, rdata, low + base + base_address,
+			    high + base + base_address,
 			    error_callback, data, vec))
 	      return 0;
 	  }
@@ -2201,10 +2197,9 @@ add_ranges_from_rnglists (
 
 	    low = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
 	    high = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
-	    if (!add_range (state, rdata,
-			    libbacktrace_add_base (low, base_address),
-			    libbacktrace_add_base (high, base_address),
-			    error_callback, data, vec))
+	    if (!add_range (state, rdata, low + base_address,
+			    high + base_address, error_callback, data,
+			    vec))
 	      return 0;
 	  }
 	  break;
@@ -2216,7 +2211,7 @@ add_ranges_from_rnglists (
 
 	    low = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
 	    length = (uintptr_t) read_uleb128 (&rnglists_buf);
-	    low = libbacktrace_add_base (low, base_address);
+	    low += base_address;
 	    if (!add_range (state, rdata, low, low + length,
 			    error_callback, data, vec))
 	      return 0;
@@ -2244,7 +2239,7 @@ add_ranges_from_rnglists (
 static int
 add_ranges (struct backtrace_state *state,
 	    const struct dwarf_sections *dwarf_sections,
-	    struct libbacktrace_base_address base_address, int is_bigendian,
+	    uintptr_t base_address, int is_bigendian,
 	    struct unit *u, uintptr_t base, const struct pcrange *pcrange,
 	    int (*add_range) (struct backtrace_state *state, void *rdata, 
 			      uintptr_t lowpc, uintptr_t highpc,
@@ -2280,8 +2275,7 @@ add_ranges (struct backtrace_state *state,
    read, 0 if there is some error.  */
 
 static int
-find_address_ranges (struct backtrace_state *state,
-		     struct libbacktrace_base_address base_address,
+find_address_ranges (struct backtrace_state *state, uintptr_t base_address,
 		     struct dwarf_buf *unit_buf,
 		     const struct dwarf_sections *dwarf_sections,
 		     int is_bigendian, struct dwarf_data *altlink,
@@ -2436,8 +2430,7 @@ find_address_ranges (struct backtrace_state *state,
    on success, 0 on failure.  */
 
 static int
-build_address_map (struct backtrace_state *state,
-		   struct libbacktrace_base_address base_address,
+build_address_map (struct backtrace_state *state, uintptr_t base_address,
 		   const struct dwarf_sections *dwarf_sections,
 		   int is_bigendian, struct dwarf_data *altlink,
 		   backtrace_error_callback error_callback, void *data,
@@ -2656,7 +2649,7 @@ add_line (struct backtrace_state *state, struct dwarf_data *ddata,
 
   /* Add in the base address here, so that we can look up the PC
      directly.  */
-  ln->pc = libbacktrace_add_base (pc, ddata->base_address);
+  ln->pc = pc + ddata->base_address;
 
   ln->filename = filename;
   ln->lineno = lineno;
@@ -4336,7 +4329,7 @@ dwarf_fileline (struct backtrace_state *state, uintptr_t pc,
 
 static struct dwarf_data *
 build_dwarf_data (struct backtrace_state *state,
-		  struct libbacktrace_base_address base_address,
+		  uintptr_t base_address,
 		  const struct dwarf_sections *dwarf_sections,
 		  int is_bigendian,
 		  struct dwarf_data *altlink,
@@ -4394,7 +4387,7 @@ build_dwarf_data (struct backtrace_state *state,
 
 int
 backtrace_dwarf_add (struct backtrace_state *state,
-		     struct libbacktrace_base_address base_address,
+		     uintptr_t base_address,
 		     const struct dwarf_sections *dwarf_sections,
 		     int is_bigendian,
 		     struct dwarf_data *fileline_altlink,

--- a/externals/tracy/public/libbacktrace/elf.cpp
+++ b/externals/tracy/public/libbacktrace/elf.cpp
@@ -643,7 +643,7 @@ elf_symbol_search (const void *vkey, const void *ventry)
 
 static int
 elf_initialize_syminfo (struct backtrace_state *state,
-			struct libbacktrace_base_address base_address,
+			uintptr_t base_address,
 			const unsigned char *symtab_data, size_t symtab_size,
 			const unsigned char *strtab, size_t strtab_size,
 			backtrace_error_callback error_callback,
@@ -709,8 +709,7 @@ elf_initialize_syminfo (struct backtrace_state *state,
 	  = *(const b_elf_addr *) (opd->data + (sym->st_value - opd->addr));
       else
 	elf_symbols[j].address = sym->st_value;
-      elf_symbols[j].address =
-	libbacktrace_add_base (elf_symbols[j].address, base_address);
+      elf_symbols[j].address += base_address;
       elf_symbols[j].size = sym->st_size;
       ++j;
     }
@@ -1201,7 +1200,14 @@ elf_fetch_bits_backward (const unsigned char **ppin,
   val = *pval;
 
   if (unlikely (pin <= pinend))
-    return 1;
+    {
+      if (bits == 0)
+	{
+	  elf_uncompress_failed ();
+	  return 0;
+	}
+      return 1;
+    }
 
   pin -= 4;
 
@@ -5706,10 +5712,10 @@ elf_uncompress_lzma_block (const unsigned char *compressed,
   /* Block header CRC.  */
   computed_crc = elf_crc32 (0, compressed + block_header_offset,
 			    block_header_size - 4);
-  stream_crc = ((uint32_t)compressed[off]
-		| ((uint32_t)compressed[off + 1] << 8)
-		| ((uint32_t)compressed[off + 2] << 16)
-		| ((uint32_t)compressed[off + 3] << 24));
+  stream_crc = (compressed[off]
+		| (compressed[off + 1] << 8)
+		| (compressed[off + 2] << 16)
+		| (compressed[off + 3] << 24));
   if (unlikely (computed_crc != stream_crc))
     {
       elf_uncompress_failed ();
@@ -6216,10 +6222,10 @@ elf_uncompress_lzma_block (const unsigned char *compressed,
 	  return 0;
 	}
       computed_crc = elf_crc32 (0, uncompressed, uncompressed_offset);
-      stream_crc = ((uint32_t)compressed[off]
-		    | ((uint32_t)compressed[off + 1] << 8)
-		    | ((uint32_t)compressed[off + 2] << 16)
-		    | ((uint32_t)compressed[off + 3] << 24));
+      stream_crc = (compressed[off]
+		    | (compressed[off + 1] << 8)
+		    | (compressed[off + 2] << 16)
+		    | (compressed[off + 3] << 24));
       if (computed_crc != stream_crc)
 	{
 	  elf_uncompress_failed ();
@@ -6319,10 +6325,10 @@ elf_uncompress_lzma (struct backtrace_state *state,
 
   /* Next comes a CRC of the stream flags.  */
   computed_crc = elf_crc32 (0, compressed + 6, 2);
-  stream_crc = ((uint32_t)compressed[8]
-		| ((uint32_t)compressed[9] << 8)
-		| ((uint32_t)compressed[10] << 16)
-		| ((uint32_t)compressed[11] << 24));
+  stream_crc = (compressed[8]
+		| (compressed[9] << 8)
+		| (compressed[10] << 16)
+		| (compressed[11] << 24));
   if (unlikely (computed_crc != stream_crc))
     {
       elf_uncompress_failed ();
@@ -6363,10 +6369,10 @@ elf_uncompress_lzma (struct backtrace_state *state,
 
   /* Before that is a footer CRC.  */
   computed_crc = elf_crc32 (0, compressed + offset, 6);
-  stream_crc = ((uint32_t)compressed[offset - 4]
-		| ((uint32_t)compressed[offset - 3] << 8)
-		| ((uint32_t)compressed[offset - 2] << 16)
-		| ((uint32_t)compressed[offset - 1] << 24));
+  stream_crc = (compressed[offset - 4]
+		| (compressed[offset - 3] << 8)
+		| (compressed[offset - 2] << 16)
+		| (compressed[offset - 1] << 24));
   if (unlikely (computed_crc != stream_crc))
     {
       elf_uncompress_failed ();
@@ -6422,10 +6428,10 @@ elf_uncompress_lzma (struct backtrace_state *state,
   /* Next is a CRC of the index.  */
   computed_crc = elf_crc32 (0, compressed + index_offset,
 			    offset - index_offset);
-  stream_crc = ((uint32_t)compressed[offset]
-		| ((uint32_t)compressed[offset + 1] << 8)
-		| ((uint32_t)compressed[offset + 2] << 16)
-		| ((uint32_t)compressed[offset + 3] << 24));
+  stream_crc = (compressed[offset]
+		| (compressed[offset + 1] << 8)
+		| (compressed[offset + 2] << 16)
+		| (compressed[offset + 3] << 24));
   if (unlikely (computed_crc != stream_crc))
     {
       elf_uncompress_failed ();
@@ -6518,8 +6524,7 @@ backtrace_uncompress_lzma (struct backtrace_state *state,
 static int
 elf_add (struct backtrace_state *state, const char *filename, int descriptor,
 	 const unsigned char *memory, size_t memory_size,
-	 struct libbacktrace_base_address base_address,
-	 struct elf_ppc64_opd_data *caller_opd,
+	 uintptr_t base_address, struct elf_ppc64_opd_data *caller_opd,
 	 backtrace_error_callback error_callback, void *data,
 	 fileline *fileline_fn, int *found_sym, int *found_dwarf,
 	 struct dwarf_data **fileline_entry, int exe, int debuginfo,
@@ -6862,8 +6867,7 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
 	    }
 	}
 
-      if (!debuginfo
-	  && !gnu_debugdata_view_valid
+      if (!gnu_debugdata_view_valid
 	  && strcmp (name, ".gnu_debugdata") == 0)
 	{
 	  if (!elf_get_view (state, descriptor, memory, memory_size,
@@ -7421,7 +7425,6 @@ phdr_callback (struct PhdrIterate *info, void *pdata)
   const char *filename;
   int descriptor;
   int does_not_exist;
-  struct libbacktrace_base_address base_address;
   fileline elf_fileline_fn;
   int found_dwarf;
 
@@ -7451,8 +7454,7 @@ phdr_callback (struct PhdrIterate *info, void *pdata)
 	return 0;
     }
 
-  base_address.m = info->dlpi_addr;
-  if (elf_add (pd->state, filename, descriptor, NULL, 0, base_address, NULL,
+  if (elf_add (pd->state, filename, descriptor, NULL, 0, info->dlpi_addr, NULL,
 	       pd->error_callback, pd->data, &elf_fileline_fn, pd->found_sym,
 	       &found_dwarf, NULL, 0, 0, NULL, 0))
     {
@@ -7541,21 +7543,11 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
   fileline elf_fileline_fn = elf_nodebug;
   struct phdr_data pd;
 
-
-  /* When using fdpic we must use dl_iterate_phdr for all modules, including
-     the main executable, so that we can get the right base address
-     mapping.  */
-  if (!libbacktrace_using_fdpic ())
-    {
-      struct libbacktrace_base_address zero_base_address;
-
-      memset (&zero_base_address, 0, sizeof zero_base_address);
-      ret = elf_add (state, filename, descriptor, NULL, 0, zero_base_address,
-		     NULL, error_callback, data, &elf_fileline_fn, &found_sym,
-		     &found_dwarf, NULL, 1, 0, NULL, 0);
-      if (!ret)
-	return 0;
-    }
+  ret = elf_add (state, filename, descriptor, NULL, 0, 0, NULL, error_callback,
+		 data, &elf_fileline_fn, &found_sym, &found_dwarf, NULL, 1, 0,
+		 NULL, 0);
+  if (!ret)
+    return 0;
 
   pd.state = state;
   pd.error_callback = error_callback;

--- a/externals/tracy/public/libbacktrace/internal.hpp
+++ b/externals/tracy/public/libbacktrace/internal.hpp
@@ -333,44 +333,10 @@ struct dwarf_sections
 
 struct dwarf_data;
 
-/* The load address mapping.  */
-
-#if defined(__FDPIC__) && defined(HAVE_DL_ITERATE_PHDR) && (defined(HAVE_LINK_H) || defined(HAVE_SYS_LINK_H))
-
-#ifdef HAVE_LINK_H
- #include <link.h>
-#endif
-#ifdef HAVE_SYS_LINK_H
- #include <sys/link.h>
-#endif
-
-#define libbacktrace_using_fdpic() (1)
-
-struct libbacktrace_base_address
-{
-  struct elf32_fdpic_loadaddr m;
-};
-
-#define libbacktrace_add_base(pc, base) \
-  ((uintptr_t) (__RELOC_POINTER ((pc), (base).m)))
-
-#else /* not _FDPIC__ */
-
-#define libbacktrace_using_fdpic() (0)
-
-struct libbacktrace_base_address
-{
-  uintptr_t m;
-};
-
-#define libbacktrace_add_base(pc, base) ((pc) + (base).m)
-
-#endif /* not _FDPIC__ */
-
 /* Add file/line information for a DWARF module.  */
 
 extern int backtrace_dwarf_add (struct backtrace_state *state,
-				struct libbacktrace_base_address base_address,
+				uintptr_t base_address,
 				const struct dwarf_sections *dwarf_sections,
 				int is_bigendian,
 				struct dwarf_data *fileline_altlink,

--- a/externals/tracy/public/libbacktrace/macho.cpp
+++ b/externals/tracy/public/libbacktrace/macho.cpp
@@ -274,14 +274,12 @@ struct macho_nlist_64
 
 /* Value found in nlist n_type field.  */
 
-#define MACH_O_N_STAB	0xe0	/* Stabs debugging symbol */
-#define MACH_O_N_TYPE	0x0e	/* Mask for type bits */
-
-/* Values found after masking with MACH_O_N_TYPE.  */
-#define MACH_O_N_UNDF	0x00	/* Undefined symbol */
+#define MACH_O_N_EXT	0x01	/* Extern symbol */
 #define MACH_O_N_ABS	0x02	/* Absolute symbol */
-#define MACH_O_N_SECT	0x0e	/* Defined in section from n_sect field */
+#define MACH_O_N_SECT	0x0e	/* Defined in section */
 
+#define MACH_O_N_TYPE	0x0e	/* Mask for type bits */
+#define MACH_O_N_STAB	0xe0	/* Stabs debugging symbol */
 
 /* Information we keep for a Mach-O symbol.  */
 
@@ -318,9 +316,8 @@ static const char * const dwarf_section_names[DEBUG_MAX] =
 /* Forward declaration.  */
 
 static int macho_add (struct backtrace_state *, const char *, int, off_t,
-		      const unsigned char *, struct libbacktrace_base_address,
-		      int, backtrace_error_callback, void *, fileline *,
-		      int *);
+		      const unsigned char *, uintptr_t, int,
+		      backtrace_error_callback, void *, fileline *, int *);
 
 /* A dummy callback function used when we can't find any debug info.  */
 
@@ -498,10 +495,10 @@ macho_defined_symbol (uint8_t type)
 {
   if ((type & MACH_O_N_STAB) != 0)
     return 0;
+  if ((type & MACH_O_N_EXT) != 0)
+    return 0;
   switch (type & MACH_O_N_TYPE)
     {
-    case MACH_O_N_UNDF:
-      return 0;
     case MACH_O_N_ABS:
       return 1;
     case MACH_O_N_SECT:
@@ -515,7 +512,7 @@ macho_defined_symbol (uint8_t type)
 
 static int
 macho_add_symtab (struct backtrace_state *state, int descriptor,
-		  struct libbacktrace_base_address base_address, int is_64,
+		  uintptr_t base_address, int is_64,
 		  off_t symoff, unsigned int nsyms, off_t stroff,
 		  unsigned int strsize,
 		  backtrace_error_callback error_callback, void *data)
@@ -630,7 +627,7 @@ macho_add_symtab (struct backtrace_state *state, int descriptor,
       if (name[0] == '_')
 	++name;
       macho_symbols[j].name = name;
-      macho_symbols[j].address = libbacktrace_add_base (value, base_address);
+      macho_symbols[j].address = value + base_address;
       ++j;
     }
 
@@ -763,8 +760,7 @@ macho_syminfo (struct backtrace_state *state, uintptr_t addr,
 static int
 macho_add_fat (struct backtrace_state *state, const char *filename,
 	       int descriptor, int swapped, off_t offset,
-	       const unsigned char *match_uuid,
-	       struct libbacktrace_base_address base_address,
+	       const unsigned char *match_uuid, uintptr_t base_address,
 	       int skip_symtab, uint32_t nfat_arch, int is_64,
 	       backtrace_error_callback error_callback, void *data,
 	       fileline *fileline_fn, int *found_sym)
@@ -866,8 +862,7 @@ macho_add_fat (struct backtrace_state *state, const char *filename,
 
 static int
 macho_add_dsym (struct backtrace_state *state, const char *filename,
-		struct libbacktrace_base_address base_address,
-		const unsigned char *uuid,
+		uintptr_t base_address, const unsigned char *uuid,
 		backtrace_error_callback error_callback, void *data,
 		fileline* fileline_fn)
 {
@@ -985,7 +980,7 @@ macho_add_dsym (struct backtrace_state *state, const char *filename,
 static int
 macho_add (struct backtrace_state *state, const char *filename, int descriptor,
 	   off_t offset, const unsigned char *match_uuid,
-	   struct libbacktrace_base_address base_address, int skip_symtab,
+	   uintptr_t base_address, int skip_symtab,
 	   backtrace_error_callback error_callback, void *data,
 	   fileline *fileline_fn, int *found_sym)
 {
@@ -1247,7 +1242,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
   c = _dyld_image_count ();
   for (i = 0; i < c; ++i)
     {
-      struct libbacktrace_base_address base_address;
+      uintptr_t base_address;
       const char *name;
       int d;
       fileline mff;
@@ -1271,7 +1266,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
 	    continue;
 	}
 
-      base_address.m = _dyld_get_image_vmaddr_slide (i);
+      base_address = _dyld_get_image_vmaddr_slide (i);
 
       mff = macho_nodebug;
       if (!macho_add (state, name, d, 0, NULL, base_address, 0,
@@ -1326,12 +1321,10 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
 		      void *data, fileline *fileline_fn)
 {
   fileline macho_fileline_fn;
-  struct libbacktrace_base_address zero_base_address;
   int found_sym;
 
   macho_fileline_fn = macho_nodebug;
-  memset (&zero_base_address, 0, sizeof zero_base_address);
-  if (!macho_add (state, filename, descriptor, 0, NULL, zero_base_address, 0,
+  if (!macho_add (state, filename, descriptor, 0, NULL, 0, 0,
 		  error_callback, data, &macho_fileline_fn, &found_sym))
     return 0;
 

--- a/externals/tracy/public/tracy/Tracy.hpp
+++ b/externals/tracy/public/tracy/Tracy.hpp
@@ -119,7 +119,6 @@
 #define TracySetProgramName(x)
 
 #define TracyFiberEnter(x)
-#define TracyFiberEnterHint(x,y)
 #define TracyFiberLeave
 
 #else
@@ -140,7 +139,6 @@
 
 #  define ZoneTransient( varname, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, TRACY_CALLSTACK, active )
 #  define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), TRACY_CALLSTACK, active )
-#  define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, TRACY_CALLSTACK, active )
 #else
 #  define ZoneNamed( varname, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
 #  define ZoneNamedN( varname, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
@@ -149,7 +147,6 @@
 
 #  define ZoneTransient( varname, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, active )
 #  define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), active )
-#  define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, active )
 #endif
 
 #define ZoneScoped ZoneNamed( ___tracy_scoped_zone, true )
@@ -290,8 +287,7 @@
 #define TracySetProgramName( name ) tracy::GetProfiler().SetProgramName( name );
 
 #ifdef TRACY_FIBERS
-#  define TracyFiberEnter( fiber ) tracy::Profiler::EnterFiber( fiber, 0 )
-#  define TracyFiberEnterHint( fiber, groupHint ) tracy::Profiler::EnterFiber( fiber, groupHint )
+#  define TracyFiberEnter( fiber ) tracy::Profiler::EnterFiber( fiber )
 #  define TracyFiberLeave tracy::Profiler::LeaveFiber()
 #endif
 

--- a/externals/tracy/public/tracy/TracyLua.hpp
+++ b/externals/tracy/public/tracy/TracyLua.hpp
@@ -188,13 +188,6 @@ static tracy_force_inline void SendLuaCallstack( lua_State* L, uint32_t depth )
     TracyQueueCommit( callstackAllocFatThread );
 }
 
-static inline void LuaShortenSrc( char* dst, const char* src )
-{
-    size_t l = std::min( (size_t)255, strlen( src ) );
-    memcpy( dst, src, l );
-    dst[l] = 0;
-}
-
 static inline int LuaZoneBeginS( lua_State* L )
 {
 #ifdef TRACY_ON_DEMAND
@@ -214,9 +207,7 @@ static inline int LuaZoneBeginS( lua_State* L )
     lua_Debug dbg;
     lua_getstack( L, 1, &dbg );
     lua_getinfo( L, "Snl", &dbg );
-    char src[256];
-    LuaShortenSrc( src, dbg.source );
-    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, src, dbg.name ? dbg.name : dbg.short_src );
+    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, dbg.source, dbg.name ? dbg.name : dbg.short_src );
 
     TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLocCallstack );
     MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
@@ -246,10 +237,8 @@ static inline int LuaZoneBeginNS( lua_State* L )
     lua_getstack( L, 1, &dbg );
     lua_getinfo( L, "Snl", &dbg );
     size_t nsz;
-    char src[256];
-    LuaShortenSrc( src, dbg.source );
     const auto name = lua_tolstring( L, 1, &nsz );
-    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, src, dbg.name ? dbg.name : dbg.short_src, name, nsz );
+    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, dbg.source, dbg.name ? dbg.name : dbg.short_src, name, nsz );
 
     TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLocCallstack );
     MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
@@ -275,9 +264,7 @@ static inline int LuaZoneBegin( lua_State* L )
     lua_Debug dbg;
     lua_getstack( L, 1, &dbg );
     lua_getinfo( L, "Snl", &dbg );
-    char src[256];
-    LuaShortenSrc( src, dbg.source );
-    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, src, dbg.name ? dbg.name : dbg.short_src );
+    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, dbg.source, dbg.name ? dbg.name : dbg.short_src );
 
     TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLoc );
     MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
@@ -303,10 +290,8 @@ static inline int LuaZoneBeginN( lua_State* L )
     lua_getstack( L, 1, &dbg );
     lua_getinfo( L, "Snl", &dbg );
     size_t nsz;
-    char src[256];
-    LuaShortenSrc( src, dbg.source );
     const auto name = lua_tolstring( L, 1, &nsz );
-    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, src, dbg.name ? dbg.name : dbg.short_src, name, nsz );
+    const auto srcloc = Profiler::AllocSourceLocation( dbg.currentline, dbg.source, dbg.name ? dbg.name : dbg.short_src, name, nsz );
 
     TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLoc );
     MemWrite( &item->zoneBegin.time, Profiler::GetTime() );


### PR DESCRIPTION
By some time ago, I noticed that Borked3DS isn't opening on android, and I have found on mandarine that tracy is the reason of this.

Maybe just downgrading tracy isn't a very nice fix, but you can take it as a temp workaround I guess.

Leaving as draft fn because I need to test still what version is the faulty.