### PR TITLE
cmake: Alias oboe::oboe to oboe

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -129,6 +129,7 @@ endif()
 # oboe
 if (ANDROID)
     add_subdirectory(oboe)
+    add_library(oboe::oboe ALIAS oboe)
 endif()
 
 # inih


### PR DESCRIPTION
So that openal-soft will detect oboe as a valid backend on Android. Fixes openal-soft not outputting any audio on Android.