### PR TITLE
Android: Update emulation_pause icon on resume

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
@@ -498,6 +498,14 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
         Choreographer.getInstance().postFrameCallback(this)
         if (NativeLibrary.isRunning()) {
             NativeLibrary.unPauseEmulation()
+            binding.inGameMenu.menu.findItem(R.id.menu_emulation_pause)?.let { menuItem ->
+                menuItem.title = resources.getString(R.string.pause_emulation)
+                menuItem.icon = ResourcesCompat.getDrawable(
+                    resources,
+                    R.drawable.ic_pause,
+                    requireContext().theme
+                )
+            }
             return
         }
 


### PR DESCRIPTION
If the fragment got paused while emualtionState also was paused manually via the menu bar, once the fragment got unpasued , the binding would still remain paused