### PR TITLE
video_core: Optimize vector math with SIMD instructions and compiler intrinsics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,38 @@ endif()
 # Set position independent code
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Enable O2 compiler optimizations
-if (MSVC)
-    add_compile_options(/O2)
-else()
-    add_compile_options(-O2)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    # Base options
+    set(SIMD_FLAGS "-O3")
+
+    # Architecture specific flags
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+        # ARM64 NEON support
+        set(SIMD_FLAGS "${SIMD_FLAGS} -march=armv8-a+simd")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)")
+        # x86_64 SSE/AVX support
+        set(SIMD_FLAGS "${SIMD_FLAGS} -msse4.1") # Ensures SSE4.1 support
+    endif()
+
+    # Enable vectorization
+    set(SIMD_FLAGS "${SIMD_FLAGS} -ftree-vectorize")
+elseif(MSVC)
+    # Base options
+    set(SIMD_FLAGS "/O2")
+
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+        # ARM64 NEON support
+        set(SIMD_FLAGS "${SIMD_FLAGS} /arch:arm64")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)")
+        # x86_64 SSE/AVX support
+        set(SIMD_FLAGS "${SIMD_FLAGS} /arch:AVX") # This includes SSE4.1
+    endif()
+
+    # Enable vectorization
+    set(SIMD_FLAGS "${SIMD_FLAGS} /Qvec")
 endif()
+
+add_compile_options("${SIMD_FLAGS}")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")

--- a/src/tests/video_core/shader.cpp
+++ b/src/tests/video_core/shader.cpp
@@ -33,10 +33,23 @@ using OpCode = nihstro::OpCode;
 using SourceRegister = nihstro::SourceRegister;
 using Type = nihstro::InlineAsm::Type;
 
-static constexpr Common::Vec4f vec4_inf = Common::Vec4f::AssignToAll(INFINITY);
-static constexpr Common::Vec4f vec4_nan = Common::Vec4f::AssignToAll(NAN);
-static constexpr Common::Vec4f vec4_one = Common::Vec4f::AssignToAll(1.0f);
-static constexpr Common::Vec4f vec4_zero = Common::Vec4f::AssignToAll(0.0f);
+static const Common::Vec4f vec4_inf = Common::Vec4f::AssignToAll(INFINITY);
+static const Common::Vec4f vec4_nan = Common::Vec4f::AssignToAll(NAN);
+static const Common::Vec4f vec4_one = Common::Vec4f::AssignToAll(1.0f);
+static const Common::Vec4f vec4_zero = Common::Vec4f::AssignToAll(0.0f);
+
+static bool IsNanEqual(const Common::Vec4f& a, const Common::Vec4f& b) {
+    for (int i = 0; i < 4; i++) {
+        if (std::isnan(a[i])) {
+            if (!std::isnan(b[i])) {
+                return false;
+            }
+        } else if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 namespace Catch {
 template <>
@@ -634,7 +647,7 @@ SHADER_TEST_CASE("MAD", "[video_core][shader]") {
     REQUIRE(shader.Run({vec4_zero, vec4_zero, vec4_zero}) == vec4_zero);
     REQUIRE(shader.Run({vec4_one, vec4_one, vec4_one}) == (vec4_one * 2.0f));
     REQUIRE(shader.Run({vec4_inf, vec4_zero, vec4_zero}) == vec4_zero);
-    REQUIRE(shader.Run({vec4_nan, vec4_zero, vec4_zero}) == vec4_nan);
+    REQUIRE(IsNanEqual(shader.Run({vec4_nan, vec4_zero, vec4_zero}), vec4_nan));
 }
 
 // Nested Loops are bugged on on the Shader-Interpreter at the moment

--- a/src/video_core/pica/output_vertex.cpp
+++ b/src/video_core/pica/output_vertex.cpp
@@ -28,21 +28,23 @@ OutputVertex::OutputVertex(const RasterizerRegs& regs, const AttributeBuffer& ou
 
     // The hardware takes the absolute and saturates vertex colors, *before* doing interpolation
     for (u32 i = 0; i < 4; ++i) {
-        const f32 c = std::fabs(color[i].ToFloat32());
-        color[i] = f24::FromFloat32(c < 1.0f ? c : 1.0f);
+        const f32 c = std::fabs(color_raw[i].ToFloat32());
+        color_raw[i] = f24::FromFloat32(c < 1.0f ? c : 1.0f);
     }
 }
 
 #define ASSERT_POS(var, pos)                                                                       \
-    static_assert(offsetof(OutputVertex, var) == pos * sizeof(f24), "Semantic at wrong "           \
-                                                                    "offset.")
+    static_assert(offsetof(OutputVertex, var##_raw) == pos * sizeof(f24), "Semantic at wrong "     \
+                                                                          "offset.")
 
 ASSERT_POS(pos, RasterizerRegs::VSOutputAttributes::POSITION_X);
 ASSERT_POS(quat, RasterizerRegs::VSOutputAttributes::QUATERNION_X);
 ASSERT_POS(color, RasterizerRegs::VSOutputAttributes::COLOR_R);
 ASSERT_POS(tc0, RasterizerRegs::VSOutputAttributes::TEXCOORD0_U);
 ASSERT_POS(tc1, RasterizerRegs::VSOutputAttributes::TEXCOORD1_U);
-ASSERT_POS(tc0_w, RasterizerRegs::VSOutputAttributes::TEXCOORD0_W);
+static_assert(offsetof(OutputVertex, tc0_w) ==
+                  RasterizerRegs::VSOutputAttributes::TEXCOORD0_W * sizeof(f24),
+              "Semantic at wrong offset.");
 ASSERT_POS(view, RasterizerRegs::VSOutputAttributes::VIEW_X);
 ASSERT_POS(tc2, RasterizerRegs::VSOutputAttributes::TEXCOORD2_U);
 

--- a/src/video_core/pica/output_vertex.h
+++ b/src/video_core/pica/output_vertex.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include "common/common_funcs.h"
 #include "common/vector_math.h"
 #include "video_core/pica_types.h"
@@ -12,39 +14,97 @@
 namespace Pica {
 
 struct RasterizerRegs;
-
 using AttributeBuffer = std::array<Common::Vec4<f24>, 16>;
 
-struct OutputVertex {
+class alignas(16) OutputVertex {
+public:
     OutputVertex() = default;
     explicit OutputVertex(const RasterizerRegs& regs, const AttributeBuffer& output);
 
-    Common::Vec4<f24> pos;
-    Common::Vec4<f24> quat;
-    Common::Vec4<f24> color;
-    Common::Vec2<f24> tc0;
-    Common::Vec2<f24> tc1;
-    f24 tc0_w;
-    INSERT_PADDING_WORDS(1);
-    Common::Vec3<f24> view;
-    INSERT_PADDING_WORDS(1);
-    Common::Vec2<f24> tc2;
+    // Store raw f24 values in arrays to control exact memory layout
+    alignas(16) std::array<f24, 4> pos_raw;   // 16 bytes
+    alignas(16) std::array<f24, 4> quat_raw;  // 16 bytes
+    alignas(16) std::array<f24, 4> color_raw; // 16 bytes
+    alignas(8) std::array<f24, 2> tc0_raw;    // 8 bytes
+    alignas(8) std::array<f24, 2> tc1_raw;    // 8 bytes
+    alignas(4) f24 tc0_w;                     // 4 bytes
+    u32 pad1;                                 // 4 bytes
+    alignas(8) std::array<f24, 3> view_raw;   // 12 bytes
+    u32 pad2;                                 // 4 bytes
+    alignas(8) std::array<f24, 2> tc2_raw;    // 8 bytes
+
+    // Accessors that create vector types on demand
+    Common::Vec4<f24> pos() const {
+        return Common::Vec4<f24>{pos_raw[0], pos_raw[1], pos_raw[2], pos_raw[3]};
+    }
+    Common::Vec4<f24> quat() const {
+        return Common::Vec4<f24>{quat_raw[0], quat_raw[1], quat_raw[2], quat_raw[3]};
+    }
+    Common::Vec4<f24> color() const {
+        return Common::Vec4<f24>{color_raw[0], color_raw[1], color_raw[2], color_raw[3]};
+    }
+    Common::Vec2<f24> tc0() const {
+        return Common::Vec2<f24>{tc0_raw[0], tc0_raw[1]};
+    }
+    Common::Vec2<f24> tc1() const {
+        return Common::Vec2<f24>{tc1_raw[0], tc1_raw[1]};
+    }
+    Common::Vec3<f24> view() const {
+        return Common::Vec3<f24>{view_raw[0], view_raw[1], view_raw[2]};
+    }
+    Common::Vec2<f24> tc2() const {
+        return Common::Vec2<f24>{tc2_raw[0], tc2_raw[1]};
+    }
+
+    // Mutable accessors
+    void set_pos(const Common::Vec4<f24>& v) {
+        pos_raw = {v.x, v.y, v.z, v.w};
+    }
+    void set_quat(const Common::Vec4<f24>& v) {
+        quat_raw = {v.x, v.y, v.z, v.w};
+    }
+    void set_color(const Common::Vec4<f24>& v) {
+        color_raw = {v.x, v.y, v.z, v.w};
+    }
+    void set_tc0(const Common::Vec2<f24>& v) {
+        tc0_raw = {v.x, v.y};
+    }
+    void set_tc1(const Common::Vec2<f24>& v) {
+        tc1_raw = {v.x, v.y};
+    }
+    void set_view(const Common::Vec3<f24>& v) {
+        view_raw = {v.x, v.y, v.z};
+    }
+    void set_tc2(const Common::Vec2<f24>& v) {
+        tc2_raw = {v.x, v.y};
+    }
 
 private:
     template <class Archive>
     void serialize(Archive& ar, const u32) {
-        ar & pos;
-        ar & quat;
-        ar & color;
-        ar & tc0;
-        ar & tc1;
+        ar & pos_raw;
+        ar & quat_raw;
+        ar & color_raw;
+        ar & tc0_raw;
+        ar & tc1_raw;
         ar & tc0_w;
-        ar & view;
-        ar & tc2;
+        ar & view_raw;
+        ar & tc2_raw;
     }
     friend class boost::serialization::access;
 };
-static_assert(std::is_trivial_v<OutputVertex>, "Structure is not POD");
-static_assert(sizeof(OutputVertex) == 24 * sizeof(f32), "OutputVertex has invalid size");
+
+static_assert(std::is_standard_layout_v<OutputVertex>, "Structure is not standard layout");
+static_assert(sizeof(OutputVertex) == 96, "OutputVertex has invalid size");
+static_assert(alignof(OutputVertex) == 16, "OutputVertex has invalid alignment");
+
+static_assert(offsetof(OutputVertex, pos_raw) == 0, "Invalid pos offset");
+static_assert(offsetof(OutputVertex, quat_raw) == 16, "Invalid quat offset");
+static_assert(offsetof(OutputVertex, color_raw) == 32, "Invalid color offset");
+static_assert(offsetof(OutputVertex, tc0_raw) == 48, "Invalid tc0 offset");
+static_assert(offsetof(OutputVertex, tc1_raw) == 56, "Invalid tc1 offset");
+static_assert(offsetof(OutputVertex, tc0_w) == 64, "Invalid tc0_w offset");
+static_assert(offsetof(OutputVertex, view_raw) == 72, "Invalid view offset");
+static_assert(offsetof(OutputVertex, tc2_raw) == 88, "Invalid tc2 offset");
 
 } // namespace Pica

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -10,7 +10,7 @@
 #include "common/common_types.h"
 
 namespace Pica {
-struct OutputVertex;
+class OutputVertex;
 }
 
 namespace Pica {

--- a/src/video_core/renderer_software/sw_clipper.cpp
+++ b/src/video_core/renderer_software/sw_clipper.cpp
@@ -13,11 +13,14 @@ namespace SwRenderer {
 
 using Pica::TexturingRegs;
 
-void FlipQuaternionIfOpposite(Common::Vec4<f24>& a, const Common::Vec4<f24>& b) {
-    if (Common::Dot(a, b) < f24::Zero()) {
-        a *= f24::FromFloat32(-1.0f);
+void FlipQuaternionIfOpposite(Pica::OutputVertex& a, const Pica::OutputVertex& b) {
+    auto quat_a = a.quat();
+    auto quat_b = b.quat();
+    if (Common::Dot(quat_a, quat_b) < f24::Zero()) {
+        quat_a *= f24::FromFloat32(-1.0f);
+        a.set_quat(quat_a);
     }
-};
+}
 
 int SignedArea(const Common::Vec2<Fix12P4>& vtx1, const Common::Vec2<Fix12P4>& vtx2,
                const Common::Vec2<Fix12P4>& vtx3) {

--- a/src/video_core/renderer_software/sw_clipper.h
+++ b/src/video_core/renderer_software/sw_clipper.h
@@ -7,6 +7,7 @@
 
 #include "common/common_types.h"
 #include "common/vector_math.h"
+#include "video_core/pica/output_vertex.h"
 #include "video_core/pica_types.h"
 
 namespace Pica {
@@ -60,7 +61,7 @@ struct Viewport {
  * Flips the quaternions if they are opposite to prevent
  * interpolating them over the wrong direction.
  */
-void FlipQuaternionIfOpposite(Common::Vec4<f24>& a, const Common::Vec4<f24>& b);
+void FlipQuaternionIfOpposite(Pica::OutputVertex& a, const Pica::OutputVertex& b);
 
 /**
  * Calculate signed area of the triangle spanned by the three argument vertices.

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -3,6 +3,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <sstream>
 #include <string_view>
 #include <fmt/format.h>
 
@@ -384,34 +385,37 @@ void EmitPrim(Vertex vtx0, Vertex vtx1, Vertex vtx2) {
 };
 
 std::string GenerateFixedGeometryShader(const PicaFixedGSConfig& config, bool separable_shader) {
-    std::string out;
+    std::stringstream out;
+
     if (separable_shader) {
-        out += "#extension GL_ARB_separate_shader_objects : enable\n";
+        out << "#extension GL_ARB_separate_shader_objects : enable\n";
     }
 
-    out += R"(
+    out << R"(
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
 )";
 
-    out += GetGSCommonSource(config.state, separable_shader);
+    out << GetGSCommonSource(config.state, separable_shader);
 
-    out += R"(
+    out << R"(
 void main() {
     Vertex prim_buffer[3];
 )";
+
     for (u32 vtx = 0; vtx < 3; ++vtx) {
-        out += fmt::format("    prim_buffer[{}].attributes = vec4[{}](", vtx,
+        out << fmt::format("    prim_buffer[{}].attributes = vec4[{}](", vtx,
                            config.state.gs_output_attributes);
         for (u32 i = 0; i < config.state.vs_output_attributes; ++i) {
-            out += fmt::format("{}vs_out_attr{}[{}]", i == 0 ? "" : ", ", i, vtx);
+            out << fmt::format("{}vs_out_attr{}[{}]", i == 0 ? "" : ", ", i, vtx);
         }
-        out += ");\n";
+        out << ");\n";
     }
-    out += "    EmitPrim(prim_buffer[0], prim_buffer[1], prim_buffer[2]);\n";
-    out += "}\n";
 
-    return out;
+    out << "    EmitPrim(prim_buffer[0], prim_buffer[1], prim_buffer[2]);\n";
+    out << "}\n";
+
+    return out.str();
 }
 } // namespace Pica::Shader::Generator::GLSL

--- a/src/video_core/shader/generator/glsl_shader_gen.h
+++ b/src/video_core/shader/generator/glsl_shader_gen.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <string>
+
 // High precision may or may not be supported in GLES3. If it isn't, use medium precision instead.
 static constexpr char fragment_shader_precision_OES[] = R"(
 #if GL_ES


### PR DESCRIPTION
Fun side effect: Refactoring OutputVertex seems to have fixed games that
would not launch under Vulkan if they used custom texture packs using the old hashing method
(ex. Bravely Default/Bravely Second). The main change being previously, there were some cases
where the size of the data structure would not equal the expected 96 bytes and perhaps this
was why they would not launch.