### PR TITLE
Android: Migrate from using `WindowInsetsController` to `WindowInsetsControllerCompat`

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/fragments/SetupFragment.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/fragments/SetupFragment.kt
@@ -15,13 +15,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowInsetsController
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -104,11 +104,9 @@ class SetupFragment : Fragment() {
         )
 
         val window = requireActivity().window
-        val insetsController = window.insetsController
-        insetsController?.setSystemBarsAppearance(
-            WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
-            WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
-        )
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            isAppearanceLightNavigationBars = true
+        }
 
         pages = mutableListOf()
         pages.apply {

--- a/src/android/app/src/main/java/io/github/borked3ds/android/ui/main/MainActivity.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/ui/main/MainActivity.kt
@@ -12,7 +12,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
-import android.view.WindowInsetsController
 import android.view.WindowManager
 import android.view.animation.PathInterpolator
 import android.widget.Toast
@@ -23,6 +22,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -94,11 +94,37 @@ class MainActivity : AppCompatActivity(), ThemeProvider {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
 
-        val insetsController = window.insetsController
-        insetsController?.setSystemBarsAppearance(
-            WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
-            WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+        val windowInsetsController = WindowInsetsControllerCompat(window, binding.root)
+        val isDarkMode = !ThemeUtil.isNightMode(this)
+
+        windowInsetsController.apply {
+            // Handle both status bar and navigation bar appearances
+            isAppearanceLightStatusBars = isDarkMode
+            isAppearanceLightNavigationBars = isDarkMode
+        }
+
+        binding.statusBarShade.setBackgroundColor(
+            ThemeUtil.getColorWithOpacity(
+                MaterialColors.getColor(
+                    binding.root,
+                    com.google.android.material.R.attr.colorSurface
+                ),
+                ThemeUtil.SYSTEM_BAR_ALPHA
+            )
         )
+        if (InsetsHelper.getSystemGestureType(applicationContext) !=
+            InsetsHelper.GESTURE_NAVIGATION
+        ) {
+            binding.navigationBarShade.setBackgroundColor(
+                ThemeUtil.getColorWithOpacity(
+                    MaterialColors.getColor(
+                        binding.root,
+                        com.google.android.material.R.attr.colorSurface
+                    ),
+                    ThemeUtil.SYSTEM_BAR_ALPHA
+                )
+            )
+        }
 
         binding.statusBarShade.setBackgroundColor(
             ThemeUtil.getColorWithOpacity(


### PR DESCRIPTION
Fixes crashing on start up on Android 9-11 due to lack of API support for `WindowInsetsController`.

Fixes #324 