### PR TITLE
renderer_vulkan.h: Set PRESENT_PIPELINES = 4

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -64,7 +64,7 @@ static_assert(sizeof(PresentUniformData) == 112,
               "PresentUniformData does not structure in shader!");
 
 class RendererVulkan : public VideoCore::RendererBase {
-    static constexpr std::size_t PRESENT_PIPELINES = 3;
+    static constexpr std::size_t PRESENT_PIPELINES = 4;
 
 public:
     explicit RendererVulkan(Core::System& system, Pica::PicaCore& pica, Frontend::EmuWindow& window,


### PR DESCRIPTION
There are actually 4 of them currently, not 3. Prevents this error:

`/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/array:208: reference std::array<vk::ShaderModule, 3>::operator[](size_type) [_Tp = vk::ShaderModule, _Nm = 3]: Assertion '__n < this->size()' failed.`

Fixes #345 