### PR TITLE
Make verbose logging the default

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
@@ -51,7 +51,7 @@ enum class BooleanSetting(
     PRIORITY_BOOST("priority_boost", Settings.SECTION_CORE, false),
     GDB_STUB("use_gdbstub", Settings.SECTION_DEBUG, false),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
-    INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, false),
+    INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, true),
     RECORD_FRAME_TIMES("record_frame_times", Settings.SECTION_DEBUG, false),
     DUMP_COMMAND_BUFFERS("dump_command_buffers", Settings.SECTION_DEBUG, false),
     SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false),

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/StringSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/StringSetting.kt
@@ -18,7 +18,7 @@ enum class StringSetting(
     CAMERA_OUTER_LEFT_CONFIG("camera_outer_left_config", Settings.SECTION_CAMERA, "_back"),
     CAMERA_OUTER_RIGHT_NAME("camera_outer_right_name", Settings.SECTION_CAMERA, "ndk"),
     CAMERA_OUTER_RIGHT_CONFIG("camera_outer_right_config", Settings.SECTION_CAMERA, "_back"),
-    LOG_FILTER("log_filter", Settings.SECTION_DEBUG, "*:Info"),
+    LOG_FILTER("log_filter", Settings.SECTION_DEBUG, "*:Trace"),
     LOG_REGEX_FILTER("log_regex_filter", Settings.SECTION_DEBUG, "");
 
     override var string: String = defaultValue

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -13,16 +13,16 @@ const char* sdl2_config_file = R"(
 # It should be in the format of "engine:[engine_name],[param1]:[value1],[param2]:[value2]..."
 # Escape characters $0 (for ':'), $1 (for ',') and $2 (for '$') can be used in values
 
-# for button input, the following devices are available:
+# For button input, the following devices are available:
 #  - "keyboard" (default) for keyboard input. Required parameters:
-#      - "code": the code of the key to bind
+#      - "code": Code of the key to bind
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
-#      - "button"(optional): the index of the button to bind
-#      - "hat"(optional): the index of the hat to bind as direction buttons
-#      - "axis"(optional): the index of the axis to bind
-#      - "direction"(only used for hat): the direction name of the hat to bind. Can be "up", "down", "left" or "right"
-#      - "threshold"(only used for axis): a float value in (-1.0, 1.0) which the button is
+#      - "joystick": Index of the joystick to bind
+#      - "button"(optional): Index of the button to bind
+#      - "hat"(optional): Index of the hat to bind as direction buttons
+#      - "axis"(optional): Index of the axis to bind
+#      - "direction"(only used for hat): Direction name of the hat to bind. Can be "up", "down", "left" or "right"
+#      - "threshold"(only used for axis): Float value in (-1.0, 1.0) which the button is
 #          triggered if the axis value crosses
 #      - "direction"(only used for axis): "+" means the button is triggered when the axis value
 #          is greater than the threshold; "-" means the button is triggered when the axis value
@@ -45,29 +45,29 @@ button_zl=
 button_zr=
 button_home=
 
-# for analog input, the following devices are available:
+# For analog input, the following devices are available:
 #  - "analog_from_button" (default) for emulating analog input from direction buttons. Required parameters:
 #      - "up", "down", "left", "right": sub-devices for each direction.
 #          Should be in the format as a button input devices using escape characters, for example, "engine$0keyboard$1code$00"
-#      - "modifier": sub-devices as a modifier.
-#      - "modifier_scale": a float number representing the applied modifier scale to the analog input.
+#      - "modifier": Sub-devices as a modifier.
+#      - "modifier_scale": Float number representing the applied modifier scale to the analog input.
 #          Must be in range of 0.0-1.0. Defaults to 0.5
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
-#      - "axis_x": the index of the axis to bind as x-axis (default to 0)
-#      - "axis_y": the index of the axis to bind as y-axis (default to 1)
+#      - "joystick": Index of the joystick to bind
+#      - "axis_x": Index of the axis to bind as x-axis (default to 0)
+#      - "axis_y": Index of the axis to bind as y-axis (default to 1)
 circle_pad=
 c_stick=
 
-# for motion input, the following devices are available:
+# For motion input, the following devices are available:
 #  - "motion_emu" (default) for emulating motion input from mouse input. Required parameters:
-#      - "update_period": update period in milliseconds (default to 100)
-#      - "sensitivity": the coefficient converting mouse movement to tilting angle (default to 0.01)
-#      - "tilt_clamp": the max value of the tilt angle in degrees (default to 90)
+#      - "update_period": Update period in milliseconds (default to 100)
+#      - "sensitivity": Coefficient converting mouse movement to tilting angle (default to 0.01)
+#      - "tilt_clamp": Max value of the tilt angle in degrees (default to 90)
 #  - "cemuhookudp" reads motion input from a udp server that uses cemuhook's udp protocol
 motion_device=
 
-# for touch input, the following devices are available:
+# For touch input, the following devices are available:
 #  - "emu_window" (default) for emulating touch input from mouse input to the emulation window. No parameters required
 #  - "cemuhookudp" reads touch input from a udp server that uses cemuhook's udp protocol
 #      - "min_x", "min_y", "max_x", "max_y": defines the udp device's touch screen coordinate system
@@ -100,8 +100,8 @@ sustained_performance =
 use_cpu_jit =
 
 # Change the Clock Frequency of the emulated 3DS CPU.
-# Underclocking can increase the performance of the game at the risk of freezing.
-# Overclocking may fix lag that happens on console, but also comes with the risk of freezing.
+# Underclocking can increase the performance at the risk of freezing.
+# Overclocking may fix lagging, but at the risk of freezing.
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
@@ -110,8 +110,8 @@ cpu_clock_percentage =
 enable_custom_cpu_ticks =
 
 # Set Custom CPU ticks
-# Set a custom value of CPU ticks. Higher values can increase performance but if they're too high,
-# it may cause the game to freeze. A range of 77-21000 is recommended.
+# Set a custom value of CPU ticks. Higher values can increase performance but if too high,
+# game may freeze. Range of 77-21000 is recommended.
 enable_custom_cpu_ticks =
 
 # Downcount will be limited to a smaller time slice.
@@ -144,7 +144,7 @@ spirv_shader_gen =
 # 0 (default): Off, 1: On
 geometry_shader =
 
-# Enables a Vulkan extension that may improve the rendering quality. (Vulkan only)
+# Enables a Vulkan extension that may improve the rendering quality.
 # 0 (default): Off, 1: On
 use_sample_shading =
 
@@ -258,11 +258,11 @@ mono_render_option =
 # true or false (default)
 swap_eyes_3d =
 
-# The name of the post processing shader to apply.
+# Name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 pp_shader_name =
 
-# The name of the shader to apply when render_3d is anaglyph.
+# Name of the shader to apply when render_3d is anaglyph.
 # Loaded from shaders/anaglyph.
 # Options (enter as strings):
 # rendepth (builtin)
@@ -346,7 +346,7 @@ custom_portrait_bottom_y =
 custom_portrait_bottom_width =
 custom_portrait_bottom_height =
 
-# Opacity of second layer when using custom layout option (bottom screen unless swapped). Useful if positioning on top of the first layer. OpenGL only.
+# Opacity of second layer when using custom layout option. Useful if positioning on top of the first layer. OpenGL only.
 custom_second_layer_opacity =
 
 # Swaps the prominent screen with the other screen.
@@ -419,6 +419,21 @@ input_type =
 input_device =
 
 [Data Storage]
+# Whether to create a virtual SD card.
+# 1 (default): Yes, 0: No
+use_virtual_sd =
+
+# Whether to use custom storage locations
+# 1: Yes, 0 (default): No
+use_custom_storage =
+
+# The path of the virtual SD card directory.
+# empty (default) will use the user_path
+sdmc_directory =
+
+# The path of NAND directory.
+# empty (default) will use the user_path
+nand_directory =
 
 [System]
 # The system model that Borked3DS will try to emulate
@@ -497,18 +512,16 @@ camera_inner_name =
 camera_inner_config =
 camera_inner_flip =
 
-[Miscellaneous]
-
 [Debugging]
 # log_filter is a filter string which removes logs below a certain logging level,
 # each of the format `<class>:<level>`.
 #
-# Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
-# Default: *:Info
+# Examples: *:Debug Kernel.SVC:Info Service.*:Critical
+# Default: *:Trace
 #
 # See src/common/logging/filter.h and src/common/logging/filter.cpp for
 # the full list of valid classes and levels.
-log_filter = *:Info
+log_filter = *:Trace
 
 # log_regex_filter is a filter that only displays logs based on the regex
 # expression in POSIX format supplied (see log_filter above). Default is "".
@@ -532,6 +545,7 @@ gdbstub_port=24689
 
 # Flush log output on every message
 # Immediately commits the debug log to file. Use this if borked3ds crashes and the log output is being cut.
+# 0: Off, 1 (default): On
 instant_debug_log =
 
 # To LLE a service module add "LLE\<module name>=true"

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -500,13 +500,13 @@
     <!-- Debug Menu -->
     <string name="logging">Logging</string>
     <string name="log_filter_name">Log Level</string>
-    <string name="log_filter_description">Select the level of verbosity to display in the log files. All messages from that level and below will be displayed. Ranges from <i>Critical</i> (i.e. minimal) to <i>Trace</i> (i.e. everything). Default is <i>Info</i>.</string>
+    <string name="log_filter_description">Select the level of verbosity to display in the log files. All messages from that level and below will be displayed. Ranges from <i>Critical</i> (i.e. minimal) to <i>Trace</i> (i.e. everything). Default is <i>Trace</i>.</string>
     <string name="log_critical">Critical</string>
     <string name="log_error">Error</string>
     <string name="log_warning">Warning</string>
-    <string name="log_info">Info (default)</string>
+    <string name="log_info">Info</string>
     <string name="log_debug">Debug</string>
-    <string name="log_trace">Trace</string>
+    <string name="log_trace">Trace (Default)</string>
     <string name="log_filter_critical">*:Critical</string>
     <string name="log_filter_error">*:Error</string>
     <string name="log_filter_warning">*:Warning</string>

--- a/src/borked3ds/default_ini.h
+++ b/src/borked3ds/default_ini.h
@@ -13,16 +13,16 @@ const char* sdl2_config_file = R"(
 # It should be in the format of "engine:[engine_name],[param1]:[value1],[param2]:[value2]..."
 # Escape characters $0 (for ':'), $1 (for ',') and $2 (for '$') can be used in values
 
-# for button input, the following devices are available:
+# For button input, the following devices are available:
 #  - "keyboard" (default) for keyboard input. Required parameters:
-#      - "code": the code of the key to bind
+#      - "code": Code of the key to bind
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
-#      - "button"(optional): the index of the button to bind
-#      - "hat"(optional): the index of the hat to bind as direction buttons
-#      - "axis"(optional): the index of the axis to bind
-#      - "direction"(only used for hat): the direction name of the hat to bind. Can be "up", "down", "left" or "right"
-#      - "threshold"(only used for axis): a float value in (-1.0, 1.0) which the button is
+#      - "joystick": Index of the joystick to bind
+#      - "button"(optional): Index of the button to bind
+#      - "hat"(optional): Index of the hat to bind as direction buttons
+#      - "axis"(optional): Index of the axis to bind
+#      - "direction"(only used for hat): Direction name of the hat to bind. Can be "up", "down", "left" or "right"
+#      - "threshold"(only used for axis): Float value in (-1.0, 1.0) which the button is
 #          triggered if the axis value crosses
 #      - "direction"(only used for axis): "+" means the button is triggered when the axis value
 #          is greater than the threshold; "-" means the button is triggered when the axis value
@@ -45,29 +45,29 @@ button_zl=
 button_zr=
 button_home=
 
-# for analog input, the following devices are available:
+# For analog input, the following devices are available:
 #  - "analog_from_button" (default) for emulating analog input from direction buttons. Required parameters:
 #      - "up", "down", "left", "right": sub-devices for each direction.
 #          Should be in the format as a button input devices using escape characters, for example, "engine$0keyboard$1code$00"
-#      - "modifier": sub-devices as a modifier.
-#      - "modifier_scale": a float number representing the applied modifier scale to the analog input.
+#      - "modifier": Sub-devices as a modifier.
+#      - "modifier_scale": Float number representing the applied modifier scale to the analog input.
 #          Must be in range of 0.0-1.0. Defaults to 0.5
 #  - "sdl" for joystick input using SDL. Required parameters:
-#      - "joystick": the index of the joystick to bind
-#      - "axis_x": the index of the axis to bind as x-axis (default to 0)
-#      - "axis_y": the index of the axis to bind as y-axis (default to 1)
+#      - "joystick": Index of the joystick to bind
+#      - "axis_x": Index of the axis to bind as x-axis (default to 0)
+#      - "axis_y": Index of the axis to bind as y-axis (default to 1)
 circle_pad=
 c_stick=
 
-# for motion input, the following devices are available:
+# For motion input, the following devices are available:
 #  - "motion_emu" (default) for emulating motion input from mouse input. Required parameters:
-#      - "update_period": update period in milliseconds (default to 100)
-#      - "sensitivity": the coefficient converting mouse movement to tilting angle (default to 0.01)
-#      - "tilt_clamp": the max value of the tilt angle in degrees (default to 90)
+#      - "update_period": Update period in milliseconds (default to 100)
+#      - "sensitivity": Coefficient converting mouse movement to tilting angle (default to 0.01)
+#      - "tilt_clamp": Max value of the tilt angle in degrees (default to 90)
 #  - "cemuhookudp" reads motion input from a udp server that uses cemuhook's udp protocol
 motion_device=
 
-# for touch input, the following devices are available:
+# For touch input, the following devices are available:
 #  - "emu_window" (default) for emulating touch input from mouse input to the emulation window. No parameters required
 #  - "cemuhookudp" reads touch input from a udp server that uses cemuhook's udp protocol
 #      - "min_x", "min_y", "max_x", "max_y": defines the udp device's touch screen coordinate system
@@ -97,8 +97,8 @@ use_cpu_jit =
 frame_skip =
 
 # Change the Clock Frequency of the emulated 3DS CPU.
-# Underclocking can increase the performance of the game at the risk of freezing.
-# Overclocking may fix lag that happens on console, but also comes with the risk of freezing.
+# Underclocking can increase performance at the risk of freezing.
+# Overclocking may fix lagging, but also at the risk of freezing.
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
@@ -107,8 +107,8 @@ cpu_clock_percentage =
 enable_custom_cpu_ticks =
 
 # Set Custom CPU ticks
-# Set a custom value of CPU ticks. Higher values can increase performance but if they're too high,
-# it may cause the game to freeze. A range of 77-21000 is recommended.
+# Set a custom value of CPU ticks. Higher values can increase performance but if too high,
+# game may freeze. Range of 77-21000 is recommended.
 enable_custom_cpu_ticks =
 
 # Downcount will be limited to a smaller time slice.
@@ -124,7 +124,7 @@ priority_boost =
 # 0: Software, 1: OpenGL (default), 2: Vulkan
 graphics_api =
 
-# Whether to compile shaders on multiple worker threads (Vulkan only)
+# Whether to compile shaders on multiple worker threads
 # 0: Off, 1: On (default)
 async_shader_compilation =
 
@@ -247,11 +247,11 @@ swap_eyes_3d =
 # 0 (default): Left, 1: Right
 mono_render_option =
 
-# The name of the post processing shader to apply.
+# Name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 pp_shader_name =
 
-# The name of the shader to apply when render_3d is anaglyph.
+# Name of the shader to apply when render_3d is anaglyph.
 # Loaded from shaders/anaglyph.
 # Options (enter as strings):
 # rendepth (builtin)
@@ -285,7 +285,7 @@ custom_bottom_y =
 custom_bottom_width =
 custom_bottom_height =
 
-# Opacity of second layer when using custom layout option (bottom screen unless swapped). Useful if positioning on top of the first layer. OpenGL only.
+# Opacity of second layer when using custom layout option. Useful if positioning on top of the first layer. OpenGL only.
 custom_second_layer_opacity =
 
 # Swaps the prominent screen with the other screen.
@@ -432,18 +432,16 @@ camera_inner_name =
 camera_inner_config =
 camera_inner_flip =
 
-[Miscellaneous]
-
 [Debugging]
 # log_filter is a filter string which removes logs below a certain logging level,
 # each of the format `<class>:<level>`.
 #
-# Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
-# Default: *:Info
+# Examples: *:Debug Kernel.SVC:Info Service.*:Critical
+# Default: *:Trace
 #
 # See src/common/logging/filter.h and src/common/logging/filter.cpp for
 # the full list of valid classes and levels.
-log_filter = *:Info
+log_filter = *:Trace
 
 # log_regex_filter is a filter that only displays logs based on the regex
 # expression in POSIX format supplied (see log_filter above). Default is "".
@@ -453,10 +451,6 @@ log_regex_filter =
 # 0 (default): Off, 1: On
 record_frame_times =
 
-# Open port for listening to GDB connections.
-use_gdbstub=false
-gdbstub_port=24689
-
 # Whether to enable additional debugging information during emulation
 # 0 (default): Off, 1: On
 renderer_debug =
@@ -464,6 +458,15 @@ renderer_debug =
 # Print Vulkan API calls, parameters and values to an identified output stream.
 # 0 (default): Off, 1: On
 dump_command_buffers =
+
+# Open port for listening to GDB connections.
+use_gdbstub=false
+gdbstub_port=24689
+
+# Flush log output on every message
+# Immediately commits the debug log to file. Use this if borked3ds crashes and the log output is being cut.
+# 0: Off, 1 (default): On
+instant_debug_log =
 
 # To LLE a service module add "LLE\<module name>=true"
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -610,7 +610,7 @@ struct Values {
     Setting<bool> delay_start_for_lle_modules{true, "delay_start_for_lle_modules"};
     Setting<bool> use_gdbstub{false, "use_gdbstub"};
     Setting<u16> gdbstub_port{24689, "gdbstub_port"};
-    Setting<bool> instant_debug_log{false, "instant_debug_log"};
+    Setting<bool> instant_debug_log{true, "instant_debug_log"};
 
     // Hacks
     SwitchableSetting<bool> enable_custom_cpu_ticks{false, "enable_custom_cpu_ticks"};
@@ -623,7 +623,7 @@ struct Values {
     SwitchableSetting<bool> upscaling_hack{false, "upscaling_hack"};
 
     // Miscellaneous
-    Setting<std::string> log_filter{"*:Info", "log_filter"};
+    Setting<std::string> log_filter{"*:Trace", "log_filter"};
     Setting<std::string> log_regex_filter{"", "log_regex_filter"};
 
     // Video Dumping


### PR DESCRIPTION
Sets the default logging level to `:Trace` rather than `:Info` and `instant_debug_log` to `true` to help with debugging and troubleshooting. Users can easily reduce the verbosity back to :Info themselves if they wish.