### PR TITLE
Fix Clang 19 and GCC-14 build errors on Linux x86_64

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -424,18 +424,18 @@ private:
     /// Image interface
     std::shared_ptr<Frontend::ImageInterface> registered_image_interface;
 
-#ifdef ENABLE_SCRIPTING
-    /// RPC Server for scripting support
-    std::unique_ptr<RPC::Server> rpc_server;
-#endif
-
-    std::unique_ptr<Service::FS::ArchiveManager> archive_manager;
-
     std::unique_ptr<Memory::MemorySystem> memory;
     std::unique_ptr<Kernel::KernelSystem> kernel;
     std::unique_ptr<Timing> timing;
 
     std::unique_ptr<Core::ExclusiveMonitor> exclusive_monitor;
+
+    std::unique_ptr<Service::FS::ArchiveManager> archive_manager;
+
+#ifdef ENABLE_SCRIPTING
+    /// RPC Server for scripting support
+    std::unique_ptr<RPC::Server> rpc_server;
+#endif
 
 private:
     static System s_instance;

--- a/src/tests/audio_core/hle/hle.cpp
+++ b/src/tests/audio_core/hle/hle.cpp
@@ -16,6 +16,16 @@
 #include "core/memory.h"
 
 TEST_CASE("DSP LLE vs HLE", "[audio_core][hle]") {
+    // Check for the required file first
+    FileUtil::SetUserPath();
+    // see tests/audio_core/lle/lle.cpp for details on dspaudio.cdc
+    std::string firm_filepath =
+        FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) + "3ds" DIR_SEP "dspaudio.cdc";
+
+    if (!FileUtil::Exists(firm_filepath)) {
+        SKIP("Test requires dspaudio.cdc");
+    }
+
     Core::System system;
     Memory::MemorySystem hle_memory{system};
     Core::Timing hle_core_timing(1, 100);
@@ -31,15 +41,6 @@ TEST_CASE("DSP LLE vs HLE", "[audio_core][hle]") {
 
     // Initialise LLE
     {
-        FileUtil::SetUserPath();
-        // see tests/audio_core/lle/lle.cpp for details on dspaudio.cdc
-        std::string firm_filepath =
-            FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) + "3ds" DIR_SEP "dspaudio.cdc";
-
-        if (!FileUtil::Exists(firm_filepath)) {
-            SKIP("Test requires dspaudio.cdc");
-        }
-
         FileUtil::IOFile firm_file(firm_filepath, "rb");
 
         std::vector<u8> firm_file_buf(firm_file.GetSize());

--- a/src/tests/audio_core/hle/source.cpp
+++ b/src/tests/audio_core/hle/source.cpp
@@ -6,374 +6,401 @@
 
 TEST_CASE_METHOD(MerryAudio::MerryAudioFixture, "Verify SourceStatus::Status::last_buffer_id 1",
                  "[audio_core][hle]") {
-    //  World's worst triangle wave generator.
-    //  Generates PCM16.
+    // World's worst triangle wave generator. Generates PCM16.
     auto fillBuffer = [this](u32* audio_buffer, size_t size, unsigned freq) {
         for (size_t i = 0; i < size; i++) {
             u32 data = (i % freq) * 256;
             audio_buffer[i] = (data << 16) | (data & 0xFFFF);
         }
-
         DSP_FlushDataCache(audio_buffer, size);
     };
 
     constexpr size_t NUM_SAMPLES = 160 * 1;
     u32* audio_buffer = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer) {
+        FAIL("Memory allocation failed for audio_buffer");
+    }
     fillBuffer(audio_buffer, NUM_SAMPLES, 160);
     u32* audio_buffer2 = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer2) {
+        FAIL("Memory allocation failed for audio_buffer2");
+    }
     fillBuffer(audio_buffer2, NUM_SAMPLES, 80);
     u32* audio_buffer3 = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer3) {
+        FAIL("Memory allocation failed for audio_buffer3");
+    }
     fillBuffer(audio_buffer3, NUM_SAMPLES, 40);
 
     MerryAudio::AudioState state;
+    bool initialized = false; // Track initialization
     {
         std::vector<u8> dspfirm;
         SECTION("HLE") {
             // The test case assumes HLE AudioCore doesn't require a valid firmware
-            InitDspCore(Settings::AudioEmulation::HLE);
             dspfirm = {0};
+            InitDspCore(Settings::AudioEmulation::HLE);
         }
         SECTION("LLE Sanity") {
+            dspfirm = loadDspFirmFromFile(); // Load firmware for LLE
+            if (dspfirm.empty()) {
+                SKIP("Couldn't load firmware\n");
+            }
             InitDspCore(Settings::AudioEmulation::LLE);
-            dspfirm = loadDspFirmFromFile();
-        }
-        if (!dspfirm.size()) {
-            SKIP("Couldn't load firmware\n");
-            return;
         }
         auto ret = audioInit(dspfirm);
         if (!ret) {
-            INFO("Couldn't init audio\n");
-            goto end;
+            SKIP("Couldn't init audio\n");
         }
         state = *ret;
+        initialized = true; // Mark as initialized only on success
     }
 
-    state.waitForSync();
-    initSharedMem(state);
-    state.notifyDsp();
-
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-
-    {
-        u16 buffer_id = 0;
-        size_t next_queue_position = 0;
-
-        state.write().source_configurations->config[0].play_position = 0;
-        state.write().source_configurations->config[0].physical_address =
-            osConvertVirtToPhys(audio_buffer3);
-        state.write().source_configurations->config[0].length = NUM_SAMPLES;
-        state.write().source_configurations->config[0].mono_or_stereo.Assign(
-            AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Stereo);
-        state.write().source_configurations->config[0].format.Assign(
-            AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
-        state.write().source_configurations->config[0].fade_in.Assign(false);
-        state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
-        state.write().source_configurations->config[0].is_looping.Assign(false);
-        state.write().source_configurations->config[0].buffer_id = ++buffer_id;
-        state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
-        state.write().source_configurations->config[0].play_position_dirty.Assign(true);
-        state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
-
-        state.write()
-            .source_configurations->config[0]
-            .buffers[next_queue_position]
-            .physical_address = osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
-        state.write().source_configurations->config[0].buffers[next_queue_position].length =
-            NUM_SAMPLES;
-        state.write().source_configurations->config[0].buffers[next_queue_position].adpcm_dirty =
-            false;
-        state.write().source_configurations->config[0].buffers[next_queue_position].is_looping =
-            false;
-        state.write().source_configurations->config[0].buffers[next_queue_position].buffer_id =
-            ++buffer_id;
-        state.write().source_configurations->config[0].buffers_dirty |= 1 << next_queue_position;
-        next_queue_position = (next_queue_position + 1) % 4;
-        state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
-        state.write().source_configurations->config[0].enable = true;
-        state.write().source_configurations->config[0].enable_dirty.Assign(true);
-
+    if (initialized) {
+        state.waitForSync();
+        initSharedMem(state);
         state.notifyDsp();
 
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            if (!state.read().source_statuses->status[0].is_enabled) {
-                state.write().source_configurations->config[0].enable = true;
-                state.write().source_configurations->config[0].enable_dirty.Assign(true);
-            }
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
 
-            if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
-                if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
-                    state.read().source_statuses->status[0].current_buffer_id == 0) {
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .physical_address =
-                        osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .length = NUM_SAMPLES;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .adpcm_dirty = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .is_looping = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .buffer_id = ++buffer_id;
-                    state.write().source_configurations->config[0].buffers_dirty |=
-                        1 << next_queue_position;
-                    next_queue_position = (next_queue_position + 1) % 4;
-                    state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
+        {
+            u16 buffer_id = 0;
+            size_t next_queue_position = 0;
+
+            state.write().source_configurations->config[0].play_position = 0;
+            state.write().source_configurations->config[0].physical_address =
+                osConvertVirtToPhys(audio_buffer3);
+            state.write().source_configurations->config[0].length = NUM_SAMPLES;
+            state.write().source_configurations->config[0].mono_or_stereo.Assign(
+                AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Stereo);
+            state.write().source_configurations->config[0].format.Assign(
+                AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
+            state.write().source_configurations->config[0].fade_in.Assign(false);
+            state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
+            state.write().source_configurations->config[0].is_looping.Assign(false);
+            state.write().source_configurations->config[0].buffer_id = ++buffer_id;
+            state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
+            state.write().source_configurations->config[0].play_position_dirty.Assign(true);
+            state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
+
+            state.write()
+                .source_configurations->config[0]
+                .buffers[next_queue_position]
+                .physical_address =
+                osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
+            state.write().source_configurations->config[0].buffers[next_queue_position].length =
+                NUM_SAMPLES;
+            state.write()
+                .source_configurations->config[0]
+                .buffers[next_queue_position]
+                .adpcm_dirty = false;
+            state.write().source_configurations->config[0].buffers[next_queue_position].is_looping =
+                false;
+            state.write().source_configurations->config[0].buffers[next_queue_position].buffer_id =
+                ++buffer_id;
+            state.write().source_configurations->config[0].buffers_dirty |= 1
+                                                                            << next_queue_position;
+            next_queue_position = (next_queue_position + 1) % 4;
+            state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
+            state.write().source_configurations->config[0].enable = true;
+            state.write().source_configurations->config[0].enable_dirty.Assign(true);
+
+            state.notifyDsp();
+
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                if (!state.read().source_statuses->status[0].is_enabled) {
+                    state.write().source_configurations->config[0].enable = true;
+                    state.write().source_configurations->config[0].enable_dirty.Assign(true);
                 }
+
+                if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
+                    if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
+                        state.read().source_statuses->status[0].current_buffer_id == 0) {
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .physical_address =
+                            osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .length = NUM_SAMPLES;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .adpcm_dirty = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .is_looping = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .buffer_id = ++buffer_id;
+                        state.write().source_configurations->config[0].buffers_dirty |=
+                            1 << next_queue_position;
+                        next_queue_position = (next_queue_position + 1) % 4;
+                        state.write().source_configurations->config[0].buffer_queue_dirty.Assign(
+                            true);
+                    }
+                }
+
+                state.notifyDsp();
             }
 
-            state.notifyDsp();
+            // current_buffer_id should be 0 if the queue is not empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
+
+            // Let the queue finish playing
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                state.notifyDsp();
+            }
+
+            // TODO: There seems to be some nuances with how the LLE firmware runs the buffer queue,
+            // that differs from the HLE implementation
+            // REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 5);
+
+            // current_buffer_id should be equal to buffer_id once the queue is empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
         }
 
-        // current_buffer_id should be 0 if the queue is not empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
-
-        // Let the queue finish playing
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            state.notifyDsp();
-        }
-
-        // TODO: There seems to be some nuances with how the LLE firmware runs the buffer queue,
-        // that differs from the HLE implementation
-        // REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 5);
-
-        // current_buffer_id should be equal to buffer_id once the queue is empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
+        audioExit(state); // Only called if initialization succeeded
     }
-
-end:
-    audioExit(state);
 }
 
 TEST_CASE_METHOD(MerryAudio::MerryAudioFixture, "Verify SourceStatus::Status::last_buffer_id 2",
                  "[audio_core][hle]") {
-    //  World's worst triangle wave generator.
-    //  Generates PCM16.
+    //  World's worst triangle wave generator. Generates PCM16.
     auto fillBuffer = [this](u32* audio_buffer, size_t size, unsigned freq) {
         for (size_t i = 0; i < size; i++) {
             u32 data = (i % freq) * 256;
             audio_buffer[i] = (data << 16) | (data & 0xFFFF);
         }
-
         DSP_FlushDataCache(audio_buffer, size);
     };
 
     constexpr size_t NUM_SAMPLES = 160 * 1;
     u32* audio_buffer = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer) {
+        FAIL("Memory allocation failed for audio_buffer");
+    }
     fillBuffer(audio_buffer, NUM_SAMPLES, 160);
     u32* audio_buffer2 = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer2) {
+        FAIL("Memory allocation failed for audio_buffer2");
+    }
     fillBuffer(audio_buffer2, NUM_SAMPLES, 80);
     u32* audio_buffer3 = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer3) {
+        FAIL("Memory allocation failed for audio_buffer3");
+    }
     fillBuffer(audio_buffer3, NUM_SAMPLES, 40);
 
     MerryAudio::AudioState state;
+    bool initialized = false; // Track initialization
     {
         std::vector<u8> dspfirm;
         SECTION("HLE") {
             // The test case assumes HLE AudioCore doesn't require a valid firmware
-            InitDspCore(Settings::AudioEmulation::HLE);
             dspfirm = {0};
+            InitDspCore(Settings::AudioEmulation::HLE);
         }
         SECTION("LLE Sanity") {
-            InitDspCore(Settings::AudioEmulation::LLE);
             dspfirm = loadDspFirmFromFile();
-        }
-        if (!dspfirm.size()) {
-            SKIP("Couldn't load firmware\n");
-            return;
+            if (dspfirm.empty()) {
+                SKIP("Couldn't load firmware\n");
+            }
+            InitDspCore(Settings::AudioEmulation::LLE);
         }
         auto ret = audioInit(dspfirm);
         if (!ret) {
-            INFO("Couldn't init audio\n");
-            goto end;
+            SKIP("Couldn't init audio\n");
         }
         state = *ret;
+        initialized = true; // Mark as initialized only on success
     }
 
-    state.waitForSync();
-    initSharedMem(state);
-    state.notifyDsp();
-
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-    state.waitForSync();
-    state.notifyDsp();
-
-    {
-        u16 buffer_id = 0;
-        size_t next_queue_position = 0;
-
-        state.write().source_configurations->config[0].play_position = 0;
-        state.write().source_configurations->config[0].physical_address =
-            osConvertVirtToPhys(audio_buffer3);
-        state.write().source_configurations->config[0].length = NUM_SAMPLES;
-        state.write().source_configurations->config[0].mono_or_stereo.Assign(
-            AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Stereo);
-        state.write().source_configurations->config[0].format.Assign(
-            AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
-        state.write().source_configurations->config[0].fade_in.Assign(false);
-        state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
-        state.write().source_configurations->config[0].is_looping.Assign(false);
-        state.write().source_configurations->config[0].buffer_id = ++buffer_id;
-        state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
-        state.write().source_configurations->config[0].play_position_dirty.Assign(true);
-        state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
-
-        state.write()
-            .source_configurations->config[0]
-            .buffers[next_queue_position]
-            .physical_address = osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
-        state.write().source_configurations->config[0].buffers[next_queue_position].length =
-            NUM_SAMPLES;
-        state.write().source_configurations->config[0].buffers[next_queue_position].adpcm_dirty =
-            false;
-        state.write().source_configurations->config[0].buffers[next_queue_position].is_looping =
-            false;
-        state.write().source_configurations->config[0].buffers[next_queue_position].buffer_id =
-            ++buffer_id;
-        state.write().source_configurations->config[0].buffers_dirty |= 1 << next_queue_position;
-        next_queue_position = (next_queue_position + 1) % 4;
-        state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
-        state.write().source_configurations->config[0].enable = true;
-        state.write().source_configurations->config[0].enable_dirty.Assign(true);
-
+    if (initialized) {
+        state.waitForSync();
+        initSharedMem(state);
         state.notifyDsp();
 
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            if (!state.read().source_statuses->status[0].is_enabled) {
-                state.write().source_configurations->config[0].enable = true;
-                state.write().source_configurations->config[0].enable_dirty.Assign(true);
-            }
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
+        state.waitForSync();
+        state.notifyDsp();
 
-            if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
-                if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
-                    state.read().source_statuses->status[0].current_buffer_id == 0) {
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .physical_address =
-                        osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .length = NUM_SAMPLES;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .adpcm_dirty = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .is_looping = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .buffer_id = ++buffer_id;
-                    state.write().source_configurations->config[0].buffers_dirty |=
-                        1 << next_queue_position;
-                    next_queue_position = (next_queue_position + 1) % 4;
-                    state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
+        {
+            u16 buffer_id = 0;
+            size_t next_queue_position = 0;
+
+            state.write().source_configurations->config[0].play_position = 0;
+            state.write().source_configurations->config[0].physical_address =
+                osConvertVirtToPhys(audio_buffer3);
+            state.write().source_configurations->config[0].length = NUM_SAMPLES;
+            state.write().source_configurations->config[0].mono_or_stereo.Assign(
+                AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Stereo);
+            state.write().source_configurations->config[0].format.Assign(
+                AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
+            state.write().source_configurations->config[0].fade_in.Assign(false);
+            state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
+            state.write().source_configurations->config[0].is_looping.Assign(false);
+            state.write().source_configurations->config[0].buffer_id = ++buffer_id;
+            state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
+            state.write().source_configurations->config[0].play_position_dirty.Assign(true);
+            state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
+
+            state.write()
+                .source_configurations->config[0]
+                .buffers[next_queue_position]
+                .physical_address =
+                osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
+            state.write().source_configurations->config[0].buffers[next_queue_position].length =
+                NUM_SAMPLES;
+            state.write()
+                .source_configurations->config[0]
+                .buffers[next_queue_position]
+                .adpcm_dirty = false;
+            state.write().source_configurations->config[0].buffers[next_queue_position].is_looping =
+                false;
+            state.write().source_configurations->config[0].buffers[next_queue_position].buffer_id =
+                ++buffer_id;
+            state.write().source_configurations->config[0].buffers_dirty |= 1
+                                                                            << next_queue_position;
+            next_queue_position = (next_queue_position + 1) % 4;
+            state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
+            state.write().source_configurations->config[0].enable = true;
+            state.write().source_configurations->config[0].enable_dirty.Assign(true);
+
+            state.notifyDsp();
+
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                if (!state.read().source_statuses->status[0].is_enabled) {
+                    state.write().source_configurations->config[0].enable = true;
+                    state.write().source_configurations->config[0].enable_dirty.Assign(true);
                 }
-            }
 
-            state.notifyDsp();
-        }
-
-        // current_buffer_id should be 0 if the queue is not empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
-
-        // Let the queue finish playing
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            state.notifyDsp();
-        }
-
-        // TODO: There seems to be some nuances with how the LLE firmware runs the buffer queue,
-        // that differs from the HLE implementation
-        // REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 5);
-
-        // current_buffer_id should be equal to buffer_id once the queue is empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
-
-        // Restart Playing
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            if (!state.read().source_statuses->status[0].is_enabled) {
-                state.write().source_configurations->config[0].enable = true;
-                state.write().source_configurations->config[0].enable_dirty.Assign(true);
-            }
-
-            if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
-                if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
-                    state.read().source_statuses->status[0].current_buffer_id == 0) {
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .physical_address =
-                        osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .length = NUM_SAMPLES;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .adpcm_dirty = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .is_looping = false;
-                    state.write()
-                        .source_configurations->config[0]
-                        .buffers[next_queue_position]
-                        .buffer_id = ++buffer_id;
-                    state.write().source_configurations->config[0].buffers_dirty |=
-                        1 << next_queue_position;
-                    next_queue_position = (next_queue_position + 1) % 4;
-                    state.write().source_configurations->config[0].buffer_queue_dirty.Assign(true);
+                if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
+                    if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
+                        state.read().source_statuses->status[0].current_buffer_id == 0) {
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .physical_address =
+                            osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .length = NUM_SAMPLES;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .adpcm_dirty = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .is_looping = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .buffer_id = ++buffer_id;
+                        state.write().source_configurations->config[0].buffers_dirty |=
+                            1 << next_queue_position;
+                        next_queue_position = (next_queue_position + 1) % 4;
+                        state.write().source_configurations->config[0].buffer_queue_dirty.Assign(
+                            true);
+                    }
                 }
+
+                state.notifyDsp();
             }
 
-            state.notifyDsp();
+            // current_buffer_id should be 0 if the queue is not empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
+
+            // Let the queue finish playing
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                state.notifyDsp();
+            }
+
+            // TODO: There seems to be some nuances with how the LLE firmware runs the buffer queue,
+            // that differs from the HLE implementation
+            // REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 5);
+
+            // current_buffer_id should be equal to buffer_id once the queue is empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
+
+            // Restart Playing
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                if (!state.read().source_statuses->status[0].is_enabled) {
+                    state.write().source_configurations->config[0].enable = true;
+                    state.write().source_configurations->config[0].enable_dirty.Assign(true);
+                }
+
+                if (state.read().source_statuses->status[0].current_buffer_id_dirty) {
+                    if (state.read().source_statuses->status[0].current_buffer_id == buffer_id ||
+                        state.read().source_statuses->status[0].current_buffer_id == 0) {
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .physical_address =
+                            osConvertVirtToPhys(buffer_id % 2 ? audio_buffer2 : audio_buffer);
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .length = NUM_SAMPLES;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .adpcm_dirty = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .is_looping = false;
+                        state.write()
+                            .source_configurations->config[0]
+                            .buffers[next_queue_position]
+                            .buffer_id = ++buffer_id;
+                        state.write().source_configurations->config[0].buffers_dirty |=
+                            1 << next_queue_position;
+                        next_queue_position = (next_queue_position + 1) % 4;
+                        state.write().source_configurations->config[0].buffer_queue_dirty.Assign(
+                            true);
+                    }
+                }
+
+                state.notifyDsp();
+            }
+
+            // current_buffer_id should be 0 if the queue is not empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
+
+            // Let the queue finish playing
+            for (size_t frame_count = 0; frame_count < 10; frame_count++) {
+                state.waitForSync();
+                state.notifyDsp();
+            }
+
+            // current_buffer_id should be equal to buffer_id once the queue is empty
+            REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
+
+            audioExit(state);
         }
-
-        // current_buffer_id should be 0 if the queue is not empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == 0);
-
-        // Let the queue finish playing
-        for (size_t frame_count = 0; frame_count < 10; frame_count++) {
-            state.waitForSync();
-            state.notifyDsp();
-        }
-
-        // current_buffer_id should be equal to buffer_id once the queue is empty
-        REQUIRE(state.read().source_statuses->status[0].last_buffer_id == buffer_id);
     }
-
-end:
-    audioExit(state);
 }

--- a/src/tests/audio_core/merryhime_3ds_audio/audio_test_biquad_filter.cpp
+++ b/src/tests/audio_core/merryhime_3ds_audio/audio_test_biquad_filter.cpp
@@ -12,141 +12,144 @@ TEST_CASE_METHOD(MerryAudio::MerryAudioFixture, "AudioTest-BiquadFilter",
             u32 data = (i % 2 == 0 ? 0x1000 : 0x2000);
             audio_buffer[i] = (data << 16) | (data & 0xFFFF);
         }
-
         DSP_FlushDataCache(audio_buffer, size);
     };
 
     constexpr size_t NUM_SAMPLES = 160 * 200;
     u32* audio_buffer = (u32*)linearAlloc(NUM_SAMPLES * sizeof(u32));
+    if (!audio_buffer) {
+        FAIL("Memory allocation failed");
+    }
     fillBuffer(audio_buffer, NUM_SAMPLES);
 
     MerryAudio::AudioState state;
+    bool state_initialized = false;
     {
         std::vector<u8> dspfirm;
         SECTION("HLE") {
             // The test case assumes HLE AudioCore doesn't require a valid firmware
-            InitDspCore(Settings::AudioEmulation::HLE);
             dspfirm = {0};
+            InitDspCore(Settings::AudioEmulation::HLE);
         }
         SECTION("LLE") {
-            InitDspCore(Settings::AudioEmulation::LLE);
             dspfirm = loadDspFirmFromFile();
-        }
-        if (!dspfirm.size()) {
-            SKIP("Couldn't load firmware\n");
-            return;
+            if (!dspfirm.size()) {
+                SKIP("Couldn't load firmware\n");
+            }
+            InitDspCore(Settings::AudioEmulation::LLE);
         }
         auto ret = audioInit(dspfirm);
         if (!ret) {
-            INFO("Couldn't init audio\n");
-            goto end;
+            SKIP("Couldn't init audio\n");
         }
         state = *ret;
+        state_initialized = true;
     }
 
-    {
-        /*
-        const s16 b0 = 0.057200221035302035 * (1 << 14);
-        const s16 b1 = 0.11440044207060407 * (1 << 14);
-        const s16 b2 = 0.0238274928983472 * (1 << 14);
-        const s16 a1 = -1.2188761083637 * (1 << 14);
-        const s16 a2 = 0.44767699250490806 * (1 << 14);
-        */
-        srand((u32)time(nullptr));
-        const s16 b0 = rand();
-        const s16 b1 = rand();
-        const s16 b2 = rand();
-        const s16 a1 = rand();
-        const s16 a2 = rand();
-
-        std::array<s32, 160> expected_output;
+    if (state_initialized) {
         {
-            s32 x1 = 0;
-            s32 x2 = 0;
-            s32 y1 = 0;
-            s32 y2 = 0;
-            for (int i = 0; i < 160; i++) {
-                const s32 x0 = (i % 4 == 0 || i % 4 == 1 ? 0x1000 : 0x2000);
-                s32 y0 = ((s32)x0 * (s32)b0 + (s32)x1 * b1 + (s32)x2 * b2 + (s32)a1 * y1 +
-                          (s32)a2 * y2) >>
-                         14;
+            /*
+            const s16 b0 = 0.057200221035302035 * (1 << 14);
+            const s16 b1 = 0.11440044207060407 * (1 << 14);
+            const s16 b2 = 0.0238274928983472 * (1 << 14);
+            const s16 a1 = -1.2188761083637 * (1 << 14);
+            const s16 a2 = 0.44767699250490806 * (1 << 14);
+            */
+            srand((u32)time(nullptr));
+            const s16 b0 = rand();
+            const s16 b1 = rand();
+            const s16 b2 = rand();
+            const s16 a1 = rand();
+            const s16 a2 = rand();
 
-                y0 = std::clamp(y0, -32768, 32767);
-                expected_output[i] = y2;
+            std::array<s32, 160> expected_output;
+            {
+                s32 x1 = 0;
+                s32 x2 = 0;
+                s32 y1 = 0;
+                s32 y2 = 0;
+                for (int i = 0; i < 160; i++) {
+                    const s32 x0 = (i % 4 == 0 || i % 4 == 1 ? 0x1000 : 0x2000);
+                    s32 y0 = ((s32)x0 * (s32)b0 + (s32)x1 * b1 + (s32)x2 * b2 + (s32)a1 * y1 +
+                              (s32)a2 * y2) >>
+                             14;
 
-                x2 = x1;
-                x1 = x0;
-                y2 = y1;
-                y1 = y0;
-            }
-        }
+                    y0 = std::clamp(y0, -32768, 32767);
+                    expected_output[i] = y2;
 
-        state.waitForSync();
-        initSharedMem(state);
-        state.write().dsp_configuration->aux_bus_enable_0_dirty.Assign(true);
-        state.write().dsp_configuration->aux_bus_enable[0] = true;
-        state.write().source_configurations->config[0].gain[1][0] = 1.0;
-        state.write().source_configurations->config[0].gain_1_dirty.Assign(true);
-        state.notifyDsp();
-        state.waitForSync();
-
-        {
-            u16 buffer_id = 0;
-
-            state.write().source_configurations->config[0].play_position = 0;
-            state.write().source_configurations->config[0].physical_address =
-                osConvertVirtToPhys(audio_buffer);
-            state.write().source_configurations->config[0].length = NUM_SAMPLES;
-            state.write().source_configurations->config[0].mono_or_stereo.Assign(
-                AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Mono);
-            state.write().source_configurations->config[0].format.Assign(
-                AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
-            state.write().source_configurations->config[0].fade_in.Assign(false);
-            state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
-            state.write().source_configurations->config[0].is_looping.Assign(false);
-            state.write().source_configurations->config[0].buffer_id = ++buffer_id;
-            state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
-            state.write().source_configurations->config[0].play_position_dirty.Assign(true);
-            state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
-
-            state.write().source_configurations->config[0].enable = true;
-            state.write().source_configurations->config[0].enable_dirty.Assign(true);
-
-            state.write().source_configurations->config[0].simple_filter.b0 = 0;
-            state.write().source_configurations->config[0].simple_filter.a1 = 0;
-            state.write().source_configurations->config[0].simple_filter_enabled.Assign(false);
-            state.write().source_configurations->config[0].biquad_filter_enabled.Assign(true);
-            state.write().source_configurations->config[0].biquad_filter.b0 = b0;
-            state.write().source_configurations->config[0].biquad_filter.b1 = b1;
-            state.write().source_configurations->config[0].biquad_filter.b2 = b2;
-            state.write().source_configurations->config[0].biquad_filter.a1 = a1;
-            state.write().source_configurations->config[0].biquad_filter.a2 = a2;
-            state.write().source_configurations->config[0].filters_enabled_dirty.Assign(true);
-            state.write().source_configurations->config[0].biquad_filter_dirty.Assign(true);
-            state.write().source_configurations->config[0].simple_filter_dirty.Assign(true);
-            state.notifyDsp();
-
-            bool continue_reading = true;
-            for (size_t frame_count = 0; continue_reading && frame_count < 10; frame_count++) {
-                state.waitForSync();
-
-                for (size_t i = 0; i < 160; i++) {
-                    if (state.read().intermediate_mix_samples->mix1.pcm32[0][i]) {
-                        for (size_t j = 0; j < 60; j++) {
-                            REQUIRE(state.read().intermediate_mix_samples->mix1.pcm32[0][j] ==
-                                    expected_output[j]);
-                        }
-                        continue_reading = false;
-                        break;
-                    }
+                    x2 = x1;
+                    x1 = x0;
+                    y2 = y1;
+                    y1 = y0;
                 }
-
-                state.notifyDsp();
             }
-            REQUIRE(continue_reading == false);
-        }
-    }
 
-end:
-    audioExit(state);
+            state.waitForSync();
+            initSharedMem(state);
+            state.write().dsp_configuration->aux_bus_enable_0_dirty.Assign(true);
+            state.write().dsp_configuration->aux_bus_enable[0] = true;
+            state.write().source_configurations->config[0].gain[1][0] = 1.0;
+            state.write().source_configurations->config[0].gain_1_dirty.Assign(true);
+            state.notifyDsp();
+            state.waitForSync();
+
+            {
+                u16 buffer_id = 0;
+
+                state.write().source_configurations->config[0].play_position = 0;
+                state.write().source_configurations->config[0].physical_address =
+                    osConvertVirtToPhys(audio_buffer);
+                state.write().source_configurations->config[0].length = NUM_SAMPLES;
+                state.write().source_configurations->config[0].mono_or_stereo.Assign(
+                    AudioCore::HLE::SourceConfiguration::Configuration::MonoOrStereo::Mono);
+                state.write().source_configurations->config[0].format.Assign(
+                    AudioCore::HLE::SourceConfiguration::Configuration::Format::PCM16);
+                state.write().source_configurations->config[0].fade_in.Assign(false);
+                state.write().source_configurations->config[0].adpcm_dirty.Assign(false);
+                state.write().source_configurations->config[0].is_looping.Assign(false);
+                state.write().source_configurations->config[0].buffer_id = ++buffer_id;
+                state.write().source_configurations->config[0].partial_reset_flag.Assign(true);
+                state.write().source_configurations->config[0].play_position_dirty.Assign(true);
+                state.write().source_configurations->config[0].embedded_buffer_dirty.Assign(true);
+
+                state.write().source_configurations->config[0].enable = true;
+                state.write().source_configurations->config[0].enable_dirty.Assign(true);
+
+                state.write().source_configurations->config[0].simple_filter.b0 = 0;
+                state.write().source_configurations->config[0].simple_filter.a1 = 0;
+                state.write().source_configurations->config[0].simple_filter_enabled.Assign(false);
+                state.write().source_configurations->config[0].biquad_filter_enabled.Assign(true);
+                state.write().source_configurations->config[0].biquad_filter.b0 = b0;
+                state.write().source_configurations->config[0].biquad_filter.b1 = b1;
+                state.write().source_configurations->config[0].biquad_filter.b2 = b2;
+                state.write().source_configurations->config[0].biquad_filter.a1 = a1;
+                state.write().source_configurations->config[0].biquad_filter.a2 = a2;
+                state.write().source_configurations->config[0].filters_enabled_dirty.Assign(true);
+                state.write().source_configurations->config[0].biquad_filter_dirty.Assign(true);
+                state.write().source_configurations->config[0].simple_filter_dirty.Assign(true);
+                state.notifyDsp();
+
+                bool continue_reading = true;
+                for (size_t frame_count = 0; continue_reading && frame_count < 10; frame_count++) {
+                    state.waitForSync();
+
+                    for (size_t i = 0; i < 160; i++) {
+                        if (state.read().intermediate_mix_samples->mix1.pcm32[0][i]) {
+                            for (size_t j = 0; j < 60; j++) {
+                                REQUIRE(state.read().intermediate_mix_samples->mix1.pcm32[0][j] ==
+                                        expected_output[j]);
+                            }
+                            continue_reading = false;
+                            break;
+                        }
+                    }
+
+                    state.notifyDsp();
+                }
+                REQUIRE(continue_reading == false);
+            }
+        }
+
+        audioExit(state);
+    }
 }


### PR DESCRIPTION
Compiling the project against Classic Teakra on Linux x86_64 using GCC-14 or Clang 19 exposes a couple of minor errors in the code. They are:

* `core.h`: One Definition Error in `class System`.
* `tests/audio_core`: Segmentation Faults whenever loading the `dspaudio.cdc` audio firmware during the testing phase fails.

This PR fixes those errors.