### PR TITLE
Android: Make SwitchSetting only allow Boolean setting types

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
@@ -37,6 +37,7 @@ enum class BooleanSetting(
     SKIP_CPU_WRITE("skip_cpu_write", Settings.SECTION_RENDERER, false),
     UPSCALING_HACK("upscaling_hack", Settings.SECTION_RENDERER, false),
     SWAP_EYES_3D("swap_eyes_3d", Settings.SECTION_RENDERER, false),
+    ENABLE_CUSTOM_CPU_TICKS("enable_custom_cpu_ticks", Settings.SECTION_CORE, false),
     DISABLE_RIGHT_EYE_RENDER("disable_right_eye_render", Settings.SECTION_RENDERER, true),
     CUSTOM_TEXTURES("custom_textures", Settings.SECTION_UTILITY, false),
     DUMP_TEXTURES("dump_textures", Settings.SECTION_UTILITY, false),
@@ -95,6 +96,8 @@ enum class BooleanSetting(
             VSYNC,
             CPU_JIT,
             CORE_DOWNCOUNT_HACK,
+            ASYNC_CUSTOM_LOADING,
+            SHADERS_ACCURATE_MUL,
             DEBUG_RENDERER
         )
 

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/IntSetting.kt
@@ -53,7 +53,6 @@ enum class IntSetting(
     GDB_PORT("gdbstub_port", Settings.SECTION_DEBUG, 24689),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
     TEXTURE_SAMPLING("texture_sampling", Settings.SECTION_RENDERER, 0),
-    ENABLE_CUSTOM_CPU_TICKS("enable_custom_cpu_ticks", Settings.SECTION_CORE, 0),
     CUSTOM_CPU_TICKS("custom_cpu_ticks", Settings.SECTION_CORE, 16000),
     OPTIMIZE_SPIRV("optimize_spirv_output", Settings.SECTION_RENDERER, 0),
     FRAME_SKIP("frame_skip", Settings.SECTION_RENDERER, 0),

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/view/SwitchSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/view/SwitchSetting.kt
@@ -10,53 +10,31 @@ import io.github.borked3ds.android.features.settings.model.AbstractIntSetting
 import io.github.borked3ds.android.features.settings.model.AbstractSetting
 
 class SwitchSetting(
-    setting: AbstractSetting,
+    setting: AbstractBooleanSetting,
     titleId: Int,
     descriptionId: Int,
     val key: String? = null,
-    val defaultValue: Any? = null
+    val defaultValue: Boolean = false
 ) : SettingsItem(setting, titleId, descriptionId) {
     override val type = TYPE_SWITCH
 
     val isChecked: Boolean
         get() {
             if (setting == null) {
-                return defaultValue as Boolean
+                return defaultValue
             }
 
-            // Try integer setting
-            try {
-                val setting = setting as AbstractIntSetting
-                return setting.int == 1
-            } catch (_: ClassCastException) {
-            }
-
-            // Try boolean setting
-            try {
-                val setting = setting as AbstractBooleanSetting
-                return setting.boolean
-            } catch (_: ClassCastException) {
-            }
+            val setting = setting as AbstractBooleanSetting
             return defaultValue as Boolean
         }
 
     /**
-     * Write a value to the backing boolean. If that boolean was previously null,
-     * initializes a new one and returns it, so it can be added to the Hashmap.
+     * Write a value to the backing boolean.
      *
      * @param checked Pretty self explanatory.
      * @return the existing setting with the new value applied.
      */
-    fun setChecked(checked: Boolean): AbstractSetting {
-        // Try integer setting
-        try {
-            val setting = setting as AbstractIntSetting
-            setting.int = if (checked) 1 else 0
-            return setting
-        } catch (_: ClassCastException) {
-        }
-
-        // Try boolean setting
+    fun setChecked(checked: Boolean): AbstractBooleanSetting {
         val setting = setting as AbstractBooleanSetting
         setting.boolean = checked
         return setting

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1797,11 +1797,11 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             add(HeaderSetting(R.string.cpu_hacks, R.string.hacks_description))
             add(
                 SwitchSetting(
-                    IntSetting.ENABLE_CUSTOM_CPU_TICKS,
+                    BooleanSetting.ENABLE_CUSTOM_CPU_TICKS,
                     R.string.enable_custom_cpu_ticks,
                     R.string.enable_custom_cpu_ticks_description,
-                    IntSetting.ENABLE_CUSTOM_CPU_TICKS.key,
-                    IntSetting.ENABLE_CUSTOM_CPU_TICKS.defaultValue
+                    BooleanSetting.ENABLE_CUSTOM_CPU_TICKS.key,
+                    BooleanSetting.ENABLE_CUSTOM_CPU_TICKS.defaultValue
                 )
             )
             add(


### PR DESCRIPTION
And move all Int settings used for switches to Boolean settings.