### PR TITLE
Android: Add Original Portrait Layout setting

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/display/ScreenLayout.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/display/ScreenLayout.kt
@@ -42,7 +42,8 @@ enum class SmallScreenPosition(val int: Int) {
 enum class PortraitScreenLayout(val int: Int) {
     // These must match what is defined in src/common/settings.h
     TOP_FULL_WIDTH(0),
-    CUSTOM_PORTRAIT_LAYOUT(1);
+    CUSTOM_PORTRAIT_LAYOUT(1),
+    ORIGINAL(2);
 
     companion object {
         fun from(int: Int): PortraitScreenLayout {

--- a/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
@@ -1011,6 +1011,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
             val layoutOptionMenuItem = when (IntSetting.PORTRAIT_SCREEN_LAYOUT.int) {
                 PortraitScreenLayout.TOP_FULL_WIDTH.int -> R.id.menu_portrait_layout_top_full
                 PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int -> R.id.menu_portrait_layout_custom
+                PortraitScreenLayout.ORIGINAL.int -> R.id.menu_portrait_layout_original
                 else -> R.id.menu_portrait_layout_top_full
             }
 
@@ -1032,6 +1033,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                             ).show()
                         }
                         screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.CUSTOM_PORTRAIT_LAYOUT.int)
+                        true
+                    }
+
+                    R.id.menu_portrait_layout_original -> {
+                        screenAdjustmentUtil.changePortraitOrientation(PortraitScreenLayout.ORIGINAL.int)
                         true
                     }
 

--- a/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
+++ b/src/android/app/src/main/res/menu/menu_portrait_screen_layout.xml
@@ -11,6 +11,10 @@
             android:id="@+id/menu_portrait_layout_custom"
             android:title="@string/emulation_screen_layout_custom" />
 
+        <item
+            android:id="@+id/menu_portrait_layout_original"
+            android:title="@string/emulation_screen_layout_original" />
+
     </group>
 
 </menu>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -32,11 +32,13 @@
     <string-array name="portraitLayouts">
         <item>@string/emulation_portrait_layout_top_full</item>
         <item>@string/emulation_screen_layout_custom</item>
+        <item>@string/emulation_screen_layout_original</item>
     </string-array>
 
     <integer-array name="portraitLayoutValues">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </integer-array>
 
     <string-array name="smallScreenPositions">

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -595,8 +595,8 @@
     <string name="emulation_screen_layout_single">Single Screen</string>
     <string name="emulation_screen_layout_sidebyside">Side by Side Screens</string>
     <string name="emulation_screen_layout_hybrid">Hybrid Screens</string>
-    <string name="emulation_screen_layout_original">Original (default)</string>
-    <string name="emulation_portrait_layout_top_full">Default</string>
+    <string name="emulation_screen_layout_original">3DS Original</string>
+    <string name="emulation_portrait_layout_top_full">Borked3DS Default</string>
     <string name="emulation_screen_layout_custom">Custom Layout</string>
     <string name="emulation_small_screen_position">Small Screen Position</string>
     <string name="small_screen_position_description">Specifies the position of the small screen relative to the large one in <b>Large Screen</b> layout mode.</string>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -52,6 +52,7 @@ enum class PortraitLayoutOption : u32 {
     // formerly mobile portrait
     PortraitTopFullWidth,
     PortraitCustomLayout,
+    PortraitOriginal
 };
 
 /** Defines where the small screen will appear relative to the large screen

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -231,6 +231,10 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
             layout = Layout::CustomFrameLayout(
                 width, height, Settings::values.swap_screen.GetValue(), is_portrait_mode);
             break;
+        case Settings::PortraitLayoutOption::PortraitOriginal:
+            layout = Layout::PortraitOriginalLayout(width, height,
+                                                    Settings::values.swap_screen.GetValue());
+            break;
         }
     } else {
         switch (layout_option) {

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -63,14 +63,24 @@ FramebufferLayout reverseLayout(FramebufferLayout layout);
 FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool is_swapped, bool upright);
 
 /**
- * Factory method for constructing the mobile Full Width Top layout
- * Two screens at top, full width, no gap between them
+ * Factory method for constructing the mobile Full Width (Default) layout
+ * Two screens at top, full width (so different heights)
  * @param width Window framebuffer width in pixels
  * @param height Window framebuffer height in pixels
  * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
  */
 FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped);
+
+/**
+ * Factory method for constructing the mobile Original layout
+ * Two screens at top, equal heights
+ * @param width Window framebuffer width in pixels
+ * @param height Window framebuffer height in pixels
+ * @param is_swapped if true, the bottom screen will be displayed above the top screen
+ * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
+ */
+FramebufferLayout PortraitOriginalLayout(u32 width, u32 height, bool is_swapped);
 
 /**
  * Factory method for constructing a FramebufferLayout with only the top or bottom screen


### PR DESCRIPTION
This adds a new layout called Original on Portrait android that keeps the two screens at the same height rather than scaling them to the same width. This matches the Default layout on desktop and allows screens to line up more correctly (especially when combined with the Screen Gap option in a different PR).