### PR TITLE
Android: Add rotate screen upright toggle to UI

### DIFF
--- a/src/android/app/src/main/java/io/github/borked3ds/android/display/ScreenAdjustmentUtil.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/display/ScreenAdjustmentUtil.kt
@@ -82,6 +82,14 @@ class ScreenAdjustmentUtil(
         activity.requestedOrientation = orientationOption
     }
 
+    fun toggleScreenUpright() {
+        val uprightBoolean = BooleanSetting.UPRIGHT_SCREEN.boolean
+        BooleanSetting.UPRIGHT_SCREEN.boolean = !uprightBoolean
+        settings.saveSetting(BooleanSetting.UPRIGHT_SCREEN, SettingsFile.FILE_NAME_CONFIG)
+        NativeLibrary.reloadSettings()
+        NativeLibrary.updateFramebuffer(NativeLibrary.isPortraitMode)
+    }
+
     companion object {
         private const val TAG = "ScreenAdjustmentUtil"
     }

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/model/BooleanSetting.kt
@@ -54,6 +54,7 @@ enum class BooleanSetting(
     GDB_STUB("use_gdbstub", Settings.SECTION_DEBUG, false),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, false),
     INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, true),
+    UPRIGHT_SCREEN("upright_screen", Settings.SECTION_LAYOUT, false),
     RECORD_FRAME_TIMES("record_frame_times", Settings.SECTION_DEBUG, false),
     DUMP_COMMAND_BUFFERS("dump_command_buffers", Settings.SECTION_DEBUG, false),
     SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false),

--- a/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1245,6 +1245,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
             add(
+                SwitchSetting(
+                    BooleanSetting.UPRIGHT_SCREEN,
+                    R.string.emulation_rotate_upright,
+                    R.string.emulation_rotate_upright_desc,
+                    BooleanSetting.UPRIGHT_SCREEN.key,
+                    BooleanSetting.UPRIGHT_SCREEN.defaultValue
+                )
+            )
+            add(
                 SingleChoiceSetting(
                     IntSetting.PORTRAIT_SCREEN_LAYOUT,
                     R.string.emulation_switch_portrait_layout,

--- a/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
+++ b/src/android/app/src/main/java/io/github/borked3ds/android/fragments/EmulationFragment.kt
@@ -340,6 +340,12 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback, Choreographer.Fram
                     true
                 }
 
+
+                R.id.menu_rotate_upright -> {
+                    screenAdjustmentUtil.toggleScreenUpright()
+                    true
+                }
+
                 R.id.menu_lock_drawer -> {
                     when (EmulationMenuSettings.drawerLockMode) {
                         DrawerLayout.LOCK_MODE_UNLOCKED -> {

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -220,6 +220,7 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.cardboard_screen_size);
     ReadSetting("Layout", Settings::values.cardboard_x_shift);
     ReadSetting("Layout", Settings::values.cardboard_y_shift);
+    ReadSetting("Layout", Settings::values.upright_screen);
 
     Settings::values.portrait_layout_option =
         static_cast<Settings::PortraitLayoutOption>(sdl2_config->GetInteger(

--- a/src/android/app/src/main/res/drawable/ic_rotate_up_right.xml
+++ b/src/android/app/src/main/res/drawable/ic_rotate_up_right.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,18l2.29,-2.29 -4.88,-4.88 -4,4L2,7.41 3.41,6l6,6 4,-4 6.3,6.29L22,12v6z"/>
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2L8,6h4v3h2V6h4L12,2z"/>
+</vector>

--- a/src/android/app/src/main/res/menu/menu_in_game.xml
+++ b/src/android/app/src/main/res/menu/menu_in_game.xml
@@ -40,8 +40,12 @@
     <item
         android:id="@+id/menu_swap_screens"
         android:icon="@drawable/ic_splitscreen"
-
         android:title="@string/emulation_swap_screens" />
+
+    <item
+        android:id="@+id/menu_rotate_upright"
+        android:icon="@drawable/ic_rotate_up_right"
+        android:title="@string/emulation_rotate_upright" />
 
     <item
         android:id="@+id/menu_lock_drawer"

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="button_start" translatable="false">START</string>
     <string name="button_home">HOME</string>
     <string name="button_swap">Swap Screens</string>
+    <string name="emulation_rotate_upright">Rotate Screen Upright</string>
+    <string name="emulation_rotate_upright_desc">Use in games which require you to rotate your 3DS to portrait mode for certain parts.</string>
     <string name="button_x" translatable="false">X</string>
     <string name="button_y" translatable="false">Y</string>
     <string name="button_l" translatable="false">L</string>

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -225,7 +225,8 @@ void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height, bool is_po
         switch (portrait_layout_option) {
         case Settings::PortraitLayoutOption::PortraitTopFullWidth:
             layout = Layout::PortraitTopFullFrameLayout(width, height,
-                                                        Settings::values.swap_screen.GetValue());
+                                                        Settings::values.swap_screen.GetValue(),
+                                                        Settings::values.upright_screen.GetValue());
             break;
         case Settings::PortraitLayoutOption::PortraitCustomLayout:
             layout = Layout::CustomFrameLayout(

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -40,11 +40,11 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool swapped, bool u
                             Settings::SmallScreenPosition::BelowLarge);
 }
 
-FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped) {
+FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool swapped, bool upright) {
     ASSERT(width > 0);
     ASSERT(height > 0);
     const float scale_factor = swapped ? 1.25f : 0.8f;
-    FramebufferLayout res = LargeFrameLayout(width, height, swapped, false, scale_factor,
+    FramebufferLayout res = LargeFrameLayout(width, height, swapped, upright, scale_factor,
                                              Settings::SmallScreenPosition::BelowLarge);
     const int shiftY = -(int)(swapped ? res.bottom_screen.top : res.top_screen.top);
     res.top_screen = res.top_screen.TranslateY(shiftY);
@@ -387,7 +387,8 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale, bool is_secondar
                          res_scale +
                      gap;
             layout =
-                PortraitTopFullFrameLayout(width, height, Settings::values.swap_screen.GetValue());
+                PortraitTopFullFrameLayout(width, height, Settings::values.swap_screen.GetValue(),
+                                           Settings::values.upright_screen.GetValue());
             break;
         case Settings::PortraitLayoutOption::PortraitOriginal:
             width = Core::kScreenTopWidth * res_scale;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -70,7 +70,8 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height, bool is_swapped, boo
  * @param is_swapped if true, the bottom screen will be displayed above the top screen
  * @return Newly created FramebufferLayout object with mobile portrait screen regions initialized
  */
-FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped);
+FramebufferLayout PortraitTopFullFrameLayout(u32 width, u32 height, bool is_swapped,
+                                             bool upright = false);
 
 /**
  * Factory method for constructing the mobile Original layout


### PR DESCRIPTION
Ports the "Rotate Screen Upright" toggle which is present in QT to Android and which is used in games which require you to rotate your 3DS to portrait mode for certain parts, like Mario And Luigi Bowser's Inside Story / Dream Team.