### PR TITLE
Fix various GCC-12 build errors

### DIFF
--- a/src/borked3ds_qt/debugger/graphics/graphics_tracing.h
+++ b/src/borked3ds_qt/debugger/graphics/graphics_tracing.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "borked3ds_qt/bootmanager.h"
 #include "borked3ds_qt/debugger/graphics/graphics_breakpoint_observer.h"
 
 namespace Core {

--- a/src/borked3ds_qt/debugger/registers.h
+++ b/src/borked3ds_qt/debugger/registers.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <QDockWidget>
+#include "borked3ds_qt/bootmanager.h"
 #include "common/common_types.h"
 
 class QTreeWidget;

--- a/src/borked3ds_qt/debugger/wait_tree.h
+++ b/src/borked3ds_qt/debugger/wait_tree.h
@@ -10,6 +10,7 @@
 #include <QDockWidget>
 #include <QTreeView>
 #include <boost/container/flat_set.hpp>
+#include "borked3ds_qt/bootmanager.h"
 #include "core/core.h"
 #include "core/hle/kernel/object.h"
 

--- a/src/borked3ds_qt/main.h
+++ b/src/borked3ds_qt/main.h
@@ -13,6 +13,7 @@
 #include <QString>
 #include <QTimer>
 #include <QTranslator>
+#include "borked3ds_qt/bootmanager.h"
 #include "borked3ds_qt/compatibility_list.h"
 #include "borked3ds_qt/hotkeys.h"
 #include "core/core.h"

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -199,7 +199,9 @@ public:
     }
 
     std::tuple<float, float> GetStatus() const override {
-        const auto [x, y] = GetAnalog(axis_x, axis_y);
+        auto analog = GetAnalog(axis_x, axis_y);
+        float x = analog.first;
+        float y = analog.second;
         const float r = std::sqrt((x * x) + (y * y));
         if (r > deadzone) {
             return {x / r * (r - deadzone) / (1 - deadzone),


### PR DESCRIPTION
These were exposed when trying to compile Borked3DS on a Raspberry Pi 4/5 running Debian Bookworm.